### PR TITLE
Pass RABBITMQ_SSL to instructions for ETR

### DIFF
--- a/src/environment_provider/execution_space/list.py
+++ b/src/environment_provider/execution_space/list.py
@@ -59,6 +59,7 @@ class List:  # pylint:disable=too-few-public-methods
                     "RABBITMQ_EXCHANGE": rabbitmq.get("exchange"),
                     "RABBITMQ_PORT": rabbitmq.get("port"),
                     "RABBITMQ_VHOST": rabbitmq.get("vhost"),
+                    "RABBITMQ_SSL": rabbitmq.get("ssl"),
                     "SOURCE_HOST": self.etos.config.get("source").get("host"),
                     "ETOS_GRAPHQL_SERVER": self.etos.debug.graphql_server,
                     "ETOS_API": self.etos.debug.etos_api,


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#20

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Pass RABBITMQ_SSL to the instructions for execution space and ETR.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
It's quite bad to implement the RABBITMQ parameters this statically. Could be done more dynamically.
Let's look at it in the future.

### Benefits
<!-- What benefits will be realized by the change? -->
It's possible to run ETOS even without SSL enabled RabbitMQ.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
