### PR TITLE
Move environment provider task to a function instead of task class.

### DIFF
--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -21,7 +21,6 @@ import logging
 import traceback
 import json
 from copy import deepcopy
-from celery.registry import tasks  # pylint:disable=import-error,no-name-in-module
 from etos_lib.etos import ETOS
 from jsontas.jsontas import JsonTas
 from environment_provider.splitter.split import Splitter
@@ -48,11 +47,10 @@ class EnvironmentProviderNotConfigured(Exception):
     """Environment provider was not configured prior to request."""
 
 
-class EnvironmentProvider(APP.Task):  # pylint:disable=too-many-instance-attributes
+class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
     """Environment provider celery Task."""
 
     logger = logging.getLogger("EnvironmentProvider")
-    name = "EnvironmentProvider"
     environment_provider_config = None
     iut_provider = None
     log_area_provider = None
@@ -88,7 +86,6 @@ class EnvironmentProvider(APP.Task):  # pylint:disable=too-many-instance-attribu
         :param suite_id: Suite ID for this task.
         :type suite_id: str
         """
-        self.update_state(state="CONFIGURING")
         self.logger.info("Configure environment provider.")
         if not self.registry.wait_for_configuration(suite_id):
             # TODO: Add link ref to docs that describe how the config is done.
@@ -141,13 +138,11 @@ class EnvironmentProvider(APP.Task):  # pylint:disable=too-many-instance-attribu
         self.dataset.add(
             "artifact_published", self.environment_provider_config.artifact_published
         )
-        self.dataset.add("tercc", self.environment_provider_config.artifact_created)
+        self.dataset.add("tercc", self.environment_provider_config.tercc)
         self.dataset.merge(self.registry.dataset(suite_id))
-        self.update_state(state="CONFIGURED")
 
     def cleanup(self):
         """Clean up by checkin in all checked out providers."""
-        self.update_state(state="FORCE_CLEANUP")
         self.logger.info("Cleanup by checking in all checked out providers.")
         for provider in self.etos.config.get("PROVIDERS"):
             try:
@@ -332,7 +327,6 @@ class EnvironmentProvider(APP.Task):  # pylint:disable=too-many-instance-attribu
         """
         try:
             self.configure(suite_id)
-            self.update_state(state="RUNNING")
             test_suites = self.create_test_suite_dict()
             for test_suite_name, test_runners in test_suites.items():
                 self.set_total_test_count_and_test_runners(test_runners)
@@ -380,8 +374,16 @@ class EnvironmentProvider(APP.Task):  # pylint:disable=too-many-instance-attribu
         finally:
             if self.etos.publisher is not None:
                 self.etos.publisher.stop()
-        self.update_state(state="SUCCESS")
 
 
-# Register the environment provider task to celery.
-tasks.register(EnvironmentProvider)
+@APP.task(name="EnvironmentProvider")
+def get_environment(suite_id):
+    """Get an environment for ETOS test executions.
+
+    :param suite_id: Suite ID to get an environment for
+    :type suite_id: str
+    :return: Test suite JSON with assigned IUTs, execution spaces and log areas.
+    :rtype: dict
+    """
+    environment_provider = EnvironmentProvider()
+    return environment_provider.run(suite_id)

--- a/src/environment_provider/lib/registry.py
+++ b/src/environment_provider/lib/registry.py
@@ -44,7 +44,6 @@ class ProviderRegistry:
         self.etos = etos
         self.jsontas = jsontas
         self.etos.config.set("PROVIDERS", [])
-        self.base_json_path = "json_files/"
         self.database = Database()
 
     def is_configured(self, suite_id):

--- a/src/environment_provider/webserver.py
+++ b/src/environment_provider/webserver.py
@@ -35,7 +35,7 @@ from environment_provider.execution_space.execution_space_provider import (
     ExecutionSpaceProvider,
 )
 from environment_provider.execution_space.execution_space import ExecutionSpace
-from .environment_provider import EnvironmentProvider
+from .environment_provider import get_environment
 
 
 class Webserver:
@@ -165,7 +165,7 @@ class Webserver:
         :type response: :obj:`falcon.response`
         """
         self.request = request
-        task = EnvironmentProvider().delay(self.suite_id)
+        task = get_environment.delay(self.suite_id)
         data = {"result": "success", "data": {"id": task.id}}
         response.status = falcon.HTTP_200
         response.media = data


### PR DESCRIPTION


<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#68

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Celery instanciates the class when it is registered causing problems
with shared memory, since every task is executed in the same instance.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits
<!-- What benefits will be realized by the change? -->
It is possible to execute several environment providers at the same time as well as concurrently and get what it is you are requesting, instead of something magical.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
