### PR TITLE
Fix a bug with providers being reused improperly

### DIFF
--- a/src/environment_provider/lib/registry.py
+++ b/src/environment_provider/lib/registry.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -102,9 +102,11 @@ class ProviderRegistry:
         :return: Provider JSON or None.
         :rtype: dict or None
         """
+        self.logger.info("Getting log area provider %r", provider_id)
         provider = self.database.reader.hget(
             "EnvironmentProvider:LogAreaProviders", provider_id
         )
+        self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
         return None
@@ -119,9 +121,11 @@ class ProviderRegistry:
         :return: Provider JSON or None.
         :rtype: dict or None
         """
+        self.logger.info("Getting iut provider %r", provider_id)
         provider = self.database.reader.hget(
             "EnvironmentProvider:IUTProviders", provider_id
         )
+        self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
         return None
@@ -136,9 +140,11 @@ class ProviderRegistry:
         :return: Provider JSON or None.
         :rtype: dict or None
         """
+        self.logger.info("Getting execution space provider %r", provider_id)
         provider = self.database.reader.hget(
             "EnvironmentProvider:ExecutionSpaceProviders", provider_id
         )
+        self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
         return None
@@ -297,6 +303,17 @@ class ProviderRegistry:
         :param dataset: Dataset to configure for suite ID.
         :type dataset: dict
         """
+        self.logger.info("Configuring environment provider.")
+        self.logger.info("Dataset: %r", dataset)
+        self.logger.info("IUT provider: %r", iut_provider.get("iut", {}).get("id"))
+        self.logger.info(
+            "Execution space provider: %r",
+            execution_space_provider.get("execution_space", {}).get("id"),
+        )
+        self.logger.info(
+            "Log area provider: %r", log_area_provider.get("log", {}).get("id")
+        )
+        self.logger.info("Expire: 3600")
         self.database.writer.hset(
             "EnvironmentProvider:{}".format(suite_id), "Dataset", json.dumps(dataset)
         )


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Fix a problem with providers being reused improperly between executions.
The problem is that the providers are stored globally with the first configuration and that configuration is never reset. This means that when the first configuration is done, then all others will use that same configuration.
Also added some more logging that was used to debug this problem and made sure that the web server part of the environment provider logs using the logging service in ETOS library.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits
<!-- What benefits will be realized by the change? -->
The ability to use different providers than the first person executing :)

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
