### PR TITLE
Fix broken prepare step in Environment Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 tags
+.vscode/*
 
 # Package files
 *.egg
@@ -48,3 +49,5 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+.python-version
+

--- a/src/environment_provider/iut/iut_provider.py
+++ b/src/environment_provider/iut/iut_provider.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/src/environment_provider/iut/iut_provider.py
+++ b/src/environment_provider/iut/iut_provider.py
@@ -144,7 +144,8 @@ class IutProvider:
                     raise IutNotAvailable(self.identity.to_string())
 
                 prepared_iuts = self.prepare(checked_out_iuts)
-                checkin = set(prepared_iuts) - set(checked_out_iuts)
+                checkin = set(checked_out_iuts) - set(prepared_iuts)
+
                 for iut in checkin:
                     self.checkin(iut)
                 self.logger.info("Prepared IUTs:")

--- a/src/environment_provider/iut/prepare.py
+++ b/src/environment_provider/iut/prepare.py
@@ -85,6 +85,7 @@ class Prepare:  # pylint:disable=too-few-public-methods
         :return: Prepared IUTs.
         :rtype: list
         """
+        iuts = deepcopy(iuts)
         try:
             if not self.prepare_ruleset:
                 self.logger.info("No defined preparation rule.")


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
Fixes eiffel-community/etos#77

### Description of the Change

- Re-allocated memory for checked out IUT data, that is passed by ref.
- Fixed bug calculation of which IUTs to check-in when prepare step is completed
- Unrelated update to .gitignore

### Alternate Designs
None

### Benefits
A working prepare step with proper check-out and check-in of OUTs

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt \<fredrik.fristedt@axis.com\>
