### PR TITLE
Fix broken prepare step in Environment Provider

### DIFF
--- a/src/environment_provider/iut/iut_provider.py
+++ b/src/environment_provider/iut/iut_provider.py
@@ -143,10 +143,9 @@ class IutProvider:
                 if len(checked_out_iuts) < minimum_amount:
                     raise IutNotAvailable(self.identity.to_string())
 
-                prepared_iuts = self.prepare(checked_out_iuts)
-                checkin = set(checked_out_iuts) - set(prepared_iuts)
+                prepared_iuts, unprepared_iuts = self.prepare(checked_out_iuts)
 
-                for iut in checkin:
+                for iut in unprepared_iuts:
                     self.checkin(iut)
                 self.logger.info("Prepared IUTs:")
                 for iut in prepared_iuts:

--- a/src/environment_provider/iut/prepare.py
+++ b/src/environment_provider/iut/prepare.py
@@ -86,6 +86,7 @@ class Prepare:  # pylint:disable=too-few-public-methods
         :rtype: list
         """
         iuts = deepcopy(iuts)
+        failed_iuts = []
         try:
             if not self.prepare_ruleset:
                 self.logger.info("No defined preparation rule.")
@@ -107,10 +108,11 @@ class Prepare:  # pylint:disable=too-few-public-methods
                 if not success:
                     self.logger.error("Unable to prepare %r.", iut)
                     iuts.remove(iut)
+                    failed_iuts.append(iut)
                 else:
                     iut.update(**deepcopy(stages))
             self.dataset.add("iuts", deepcopy(iuts))
-            return iuts
+            return iuts, failed_iuts
         finally:
             # Re-add the config that was popped in __init__.
             self.dataset.add("config", self.config)


### PR DESCRIPTION
### Applicable Issues
Fixes eiffel-community/etos#77

### Description of the Change
Fixes a bug that cause improper check-in of IUTs

### Alternate Designs
None

### Benefits
IUTs that are used in testing stays checked out until testing is done.

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt \<fredrik.fristedt@axis.com\>
