### PR TITLE
Support configurating the wait timeouts

### DIFF
--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -104,10 +104,20 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         self.log_area_provider = self.registry.log_area_provider(suite_id)
         self.execution_space_provider = self.registry.execution_space_provider(suite_id)
 
-        self.etos.config.set("EVENT_DATA_TIMEOUT", 10)
-        self.etos.config.set("WAIT_FOR_IUT_TIMEOUT", 10)
-        self.etos.config.set("WAIT_FOR_EXECUTION_SPACE_TIMEOUT", 10)
-        self.etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 10)
+        self.etos.config.set(
+            "EVENT_DATA_TIMEOUT", int(os.getenv("ETOS_EVENT_DATA_TIMEOUT", "10"))
+        )
+        self.etos.config.set(
+            "WAIT_FOR_IUT_TIMEOUT", int(os.getenv("ETOS_WAIT_FOR_IUT_TIMEOUT", "10"))
+        )
+        self.etos.config.set(
+            "WAIT_FOR_EXECUTION_SPACE_TIMEOUT",
+            int(os.getenv("ETOS_WAIT_FOR_EXECUTION_SPACE_TIMEOUT", "10")),
+        )
+        self.etos.config.set(
+            "WAIT_FOR_LOG_AREA_TIMEOUT",
+            int(os.getenv("ETOS_WAIT_FOR_LOG_AREA_TIMEOUT", "10")),
+        )
         self.etos.config.set("SUITE_ID", suite_id)
 
         self.etos.config.rabbitmq_publisher_from_environment()
@@ -139,7 +149,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         self.dataset.add("custom_data", self.environment_provider_config.custom_data)
         self.dataset.add("uuid", str(uuid.uuid4()))
         self.dataset.add(
-            "artifact_created", self.environment_provider_config.artifact_created
+            "artifact_create", self.environment_provider_config.artifact_created
         )
         self.dataset.add(
             "artifact_published", self.environment_provider_config.artifact_published

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -149,7 +149,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         self.dataset.add("custom_data", self.environment_provider_config.custom_data)
         self.dataset.add("uuid", str(uuid.uuid4()))
         self.dataset.add(
-            "artifact_create", self.environment_provider_config.artifact_created
+            "artifact_created", self.environment_provider_config.artifact_created
         )
         self.dataset.add(
             "artifact_published", self.environment_provider_config.artifact_published


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#80

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make sure that one can configure the wait timeouts in the environment provider.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could use another system other than environment variables, which might be a bit clearer.
However since we are already using environment variables, it feels correct to use them here as well.

### Benefits
<!-- What benefits will be realized by the change? -->
Able to configure wait times in ETOS. Sometimes it's okay to wait more than 10 seconds for an IUT.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
