### PR TITLE
Add a new IUT provider handler for external IUTs

### DIFF
--- a/src/environment_provider/external_iut/__init__.py
+++ b/src/environment_provider/external_iut/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External IUT package."""

--- a/src/environment_provider/external_iut/provider.py
+++ b/src/environment_provider/external_iut/provider.py
@@ -1,0 +1,272 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External IUT provider."""
+from json.decoder import JSONDecodeError
+import time
+import logging
+from copy import deepcopy
+
+import requests
+from packageurl import PackageURL
+
+from environment_provider.iut.exceptions import (
+    IutCheckinFailed,
+    IutCheckoutFailed,
+    IutNotAvailable,
+)
+from environment_provider.iut.iut import Iut
+
+
+class Provider:
+    """A generic IUT provider facility for getting IUTs from an external source.
+
+    The ruleset must provide this structure:
+
+    {
+        "status": {
+            "host": "host to status endpoint"
+        },
+        "start": {
+            "host": "host to start endpoint"
+        },
+        "stop": {
+            "host": "host to stop endpoint"
+        }
+    }
+    """
+
+    logger = logging.getLogger("External IUTProvider")
+
+    def __init__(self, etos, jsontas, ruleset):
+        """Initialize IUT provider.
+
+        :param etos: ETOS library instance.
+        :type etos: :obj:`etos_lib.etos.Etos`
+        :param jsontas: JSONTas instance used to evaluate the rulesets.
+        :type jsontas: :obj:`jsontas.jsontas.JsonTas`
+        :param ruleset: JSONTas ruleset for handling IUTs.
+        :type ruleset: dict
+        """
+        self.etos = etos
+        self.etos.config.set("iuts", [])
+        self.dataset = jsontas.dataset
+        self.ruleset = ruleset
+        self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.logger.info("Initialized external IUT provider %r", self.id)
+
+    @property
+    def identity(self):
+        """IUT Identity.
+
+        :return: IUT identity as PURL object.
+        :rtype: :obj:`packageurl.PackageURL`
+        """
+        return self.dataset.get("identity")
+
+    def checkin(self, iut):
+        """Check in IUTs.
+
+        :param iut: IUT to checkin.
+        :type iut: :obj:`environment_provider.iut.iut.Iut` or list
+        """
+        end = self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
+
+        if not isinstance(iut, list):
+            self.logger.debug("Check in IUT %r (timeout %ds)", iut, end)
+            iut = [iut]
+        else:
+            self.logger.debug("Check in IUTs %r (timeout %ds)", iut, end)
+        iuts = [iut.as_dict for iut in iut]
+
+        host = self.ruleset.get("stop", {}).get("host")
+        timeout = time.time() + end
+        while time.time() < timeout:
+            time.sleep(2)
+            try:
+                response = requests.post(host, json=iuts)
+                if response.status_code == requests.codes["no_content"]:
+                    return
+                response = response.json()
+                if response.get("error") is not None:
+                    raise IutCheckinFailed(
+                        f"Unable to check in {iuts} ({response.get('error')})"
+                    )
+            except ConnectionError:
+                self.logger.error("Error connecting to %r", host)
+                continue
+        raise TimeoutError(f"Unable to stop external provider {self.id!r}")
+
+    def checkin_all(self):
+        """Check in all IUTs.
+
+        This method does the same as 'checkin'. It exists for API consistency.
+        """
+        self.logger.debug("Checking in all checked out IUTs")
+        self.checkin(self.dataset.get("iuts", []))
+
+    def start(self, minimum_amount, maximum_amount):
+        """Send a start request to an external IUT provider.
+
+        :param minimum_amount: The minimum amount of IUTs to request.
+        :type minimum_amount: int
+        :param maximum_amount: The maximum amount of IUTs to request.
+        :type maximum_amount: int
+        :return: The ID of the external IUT provider request.
+        :rtype: str
+        """
+        self.logger.debug("Start external IUT provider")
+        data = {
+            "minimum_amount": minimum_amount,
+            "maximum_amount": maximum_amount,
+            "identity": self.identity.to_string(),
+            "artifact_id": self.dataset.get("artifact_id"),
+            "artifact_created": self.dataset.get("artifact_created"),
+            "artifact_published": self.dataset.get("artifact_published"),
+            "tercc": self.dataset.get("tercc"),
+            "dataset": self.dataset.get("dataset"),
+            "context": self.dataset.get("context"),
+        }
+        response_iterator = self.etos.http.retry(
+            "POST",
+            self.ruleset.get("start", {}).get("host"),
+            json=data,
+        )
+        try:
+            for response in response_iterator:
+                return response.get("id")
+        except ConnectionError as http_error:
+            self.logger.error(
+                "Could not start external provider due to a connection error"
+            )
+            raise TimeoutError(
+                f"Unable to start external provider {self.id!r}"
+            ) from http_error
+        raise TimeoutError(f"Unable to start external provider {self.id!r}")
+
+    def wait(self, provider_id):
+        """Wait for external IUT provider to finish its request.
+
+        :param provider_id: The ID of the external IUT provider request.
+        :type provider_id: str
+        :return: The response from the external IUT provider.
+        :rtype: dict
+        """
+        self.logger.debug(
+            "Waiting for external IUT provider (%ds timeout)",
+            self.etos.config.get("WAIT_FOR_IUT_TIMEOUT"),
+        )
+
+        host = self.ruleset.get("status", {}).get("host")
+        timeout = time.time() + self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
+
+        response = None
+        while time.time() < timeout:
+            time.sleep(2)
+            try:
+                response = requests.get(host, params={"id": provider_id})
+                self.check_error(response)
+                response = response.json()
+            except ConnectionError:
+                self.logger.error("Error connecting to %r", host)
+                continue
+
+            if response.get("status") == "FAILED":
+                raise IutCheckoutFailed(response.get("description"))
+            if response.get("status") == "DONE":
+                break
+        else:
+            raise TimeoutError(
+                f"Status request timed out after {self.etos.config.get('WAIT_FOR_IUT_TIMEOUT')}s"
+            )
+        return response
+
+    def check_error(self, response):
+        """Check response for errors and try to translate them to something usable.
+
+        :param response: The response from the external IUT provider.
+        :type response: dict
+        """
+        self.logger.debug("Checking response from external IUT provider")
+        try:
+            if response.json().get("error") is not None:
+                self.logger.error(response.json().get("error"))
+        except JSONDecodeError:
+            self.logger.error("Could not parse response as JSON")
+
+        if response.status_code == requests.codes["not_found"]:
+            raise IutNotAvailable(
+                f"External provider {self.id!r} did not respond properly"
+            )
+        if response.status_code == requests.codes["bad_request"]:
+            raise RuntimeError(
+                f"IUT provider for {self.id!r} is not properly configured"
+            )
+
+        # This should work, no other errors found.
+        # If this does not work, propagate JSONDecodeError up the stack.
+        self.logger.debug("Status for response %r", response.json().get("status"))
+
+    def build_iuts(self, response):
+        """Build IUT objects from external IUT provider response.
+
+        :param response: The response from the external IUT provider.
+        :type response: dict
+        :return: A list of IUTs.
+        :rtype: list
+        """
+        iuts = []
+        for iut in response.get("iuts", []):
+            if iut.get("identity") is None:
+                iut["identity"] = self.identity
+            else:
+                iut["identity"] = PackageURL.from_string(iut.get("identity"))
+            iuts.append(Iut(provider_id=self.id, **iut))
+        return iuts
+
+    def request_and_wait_for_iuts(self, minimum_amount=0, maximum_amount=100):
+        """Wait for IUTs from an external IUT provider.
+
+        :raises: IutNotAvailable: If there are no available IUTs.
+
+        :param minimum_amount: Minimum amount of IUTs to checkout.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of IUTs to checkout.
+        :type maximum_amount: int
+        :return: List of checked out IUTs.
+        :rtype: list
+        """
+        try:
+            provider_id = self.start(minimum_amount, maximum_amount)
+            response = self.wait(provider_id)
+            iuts = self.build_iuts(response)
+            if len(iuts) < minimum_amount:
+                raise IutNotAvailable(self.identity.to_string())
+            if len(iuts) > maximum_amount:
+                self.logger.warning(
+                    "Too many IUTs from external IUT provider %r. (Expected: %d, Got %d)",
+                    self.id,
+                    maximum_amount,
+                    len(iuts),
+                )
+                extra = iuts[maximum_amount:]
+                iuts = iuts[:maximum_amount]
+                for iut in extra:
+                    self.checkin(iut)
+            self.dataset.add("iuts", deepcopy(iuts))
+        except:  # pylint:disable=bare-except
+            self.checkin_all()
+            raise
+        return iuts

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+mock
+tox
+pytest
+pytest-cov

--- a/tests/external_iut/__init__.py
+++ b/tests/external_iut/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External IUT tests."""

--- a/tests/external_iut/test_external_iut.py
+++ b/tests/external_iut/test_external_iut.py
@@ -1,0 +1,551 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for the external IUT."""
+import os
+import logging
+import unittest
+
+from etos_lib import ETOS
+from jsontas.jsontas import JsonTas
+from packageurl import PackageURL
+
+from tests.library.fake_server import FakeServer
+
+from environment_provider.external_iut.provider import Provider
+from environment_provider.iut.exceptions import (
+    IutCheckinFailed,
+    IutCheckoutFailed,
+    IutNotAvailable,
+)
+from environment_provider.iut.iut import Iut
+
+
+class TestExternalIUT(unittest.TestCase):
+    """Test the external IUT provider."""
+
+    logger = logging.getLogger(__name__)
+
+    def test_provider_start(self):
+        """Test that it is possible to start an external IUT provider.
+
+        Approval criteria:
+            - It shall be possible to send start to an external IUT provider.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a start request.
+            3. Verify that the ID from the start request is returned.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        expected_start_id = "123"
+
+        with FakeServer("ok", {"id": expected_start_id}) as server:
+            ruleset = {"id": "test_provider_start", "start": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a start request.")
+            start_id = provider.start(1, 2)
+            self.logger.info(
+                "STEP: Verify that the ID from the start request is returned."
+            )
+            self.assertEqual(start_id, expected_start_id)
+
+    def test_provider_start_http_exception(self):
+        """Test that the start method tries again if there's an HTTP error.
+
+        Approval criteria:
+            - The start method shall try again on HTTP errors.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a start request that fails.
+            3. Verify that the start method tries again on HTTP errors.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        expected_start_id = "123"
+
+        with FakeServer(
+            ["bad_request", "ok"], [{}, {"id": expected_start_id}]
+        ) as server:
+            ruleset = {
+                "id": "test_provider_start_http_exception",
+                "start": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a start request that fails.")
+            start_id = provider.start(1, 2)
+            self.logger.info(
+                "STEP: Verify that the start method tries again on HTTP errors."
+            )
+            self.assertGreaterEqual(server.nbr_of_requests, 2)
+            self.assertEqual(start_id, expected_start_id)
+
+    def test_provider_start_timeout(self):
+        """Test that the start method raises a TimeoutError.
+
+        Approval criteria:
+            - The start method shall raise TimeoutError if the timeout is reached.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a start request which will never finish.
+            3. Verify that the start method raises TimeoutError.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        os.environ["ETOS_DEFAULT_HTTP_TIMEOUT"] = "1"
+
+        with FakeServer("bad_request", {}) as server:
+            ruleset = {
+                "id": "test_provider_start_timeout",
+                "start": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a start request which will never finish.")
+
+            with self.assertRaises(TimeoutError):
+                self.logger.info(
+                    "STEP: Verify that the start method raises TimeoutError."
+                )
+                provider.start(1, 2)
+
+    def test_provider_stop(self):
+        """Test that it is possible to checkin an external IUT provider.
+
+        Approval criteria:
+            - It shall be possible to send stop to an external IUT provider.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request for a single IUT.
+            3. Verify that the stop endpoint is called.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        iut = Iut(test_iut=1)
+
+        with FakeServer("no_content", {}) as server:
+            ruleset = {"id": "test_provider_stop", "stop": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request for a single IUT.")
+            provider.checkin(iut)
+            self.logger.info("STEP: Verify that the stop endpoint is called.")
+            self.assertEqual(server.nbr_of_requests, 1)
+            self.assertEqual(server.requests, [[iut.as_dict]])
+
+    def test_provider_stop_many(self):
+        """Test that it is possible to checkin an external IUT provider with many IUTs.
+
+        Approval criteria:
+            - It shall be possible to send stop to an external IUT provider with multiple IUTs.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request for multiple IUTs.
+            3. Verify that the stop endpoint is called.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        iuts = [Iut(test_iut=1), Iut(test_iut=2)]
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+            "iuts": iuts,
+        }
+        dict_iuts = [iut.as_dict for iut in iuts]
+
+        with FakeServer("no_content", {}) as server:
+            ruleset = {"id": "test_provider_stop_many", "stop": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request for multiple IUTs.")
+            provider.checkin_all()
+            self.logger.info("STEP: Verify that the stop endpoint is called.")
+            self.assertEqual(server.nbr_of_requests, 1)
+            self.assertEqual(server.requests, [dict_iuts])
+
+    def test_provider_stop_failed(self):
+        """Test that the checkin method raises an IutCheckinFailed exception.
+
+        Approval criteria:
+            - The checkin method shall fail with an IutCheckinFailed exception.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request that fails.
+            3. Verify that the checkin method raises IutCheckinFailed exception.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        iut = Iut(test_iut=1)
+
+        with FakeServer("bad_request", {"error": "no"}) as server:
+            ruleset = {"id": "test_provider_stop_failed", "stop": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request that fails.")
+            with self.assertRaises(IutCheckinFailed):
+                self.logger.info(
+                    "STEP: Verify that the checkin method raises IutCheckinFailed exception."
+                )
+                provider.checkin(iut)
+
+    def test_provider_stop_timeout(self):
+        """Test that the checkin method raises a TimeoutError when timed out.
+
+        Approval criteria:
+            - The checkin method shall raise TimeoutError when timed out.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request for IUTs that times out.
+            3. Verify that the checkin method raises a TimeoutError.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        iut = Iut(test_iut=1)
+        with FakeServer("bad_request", {}) as server:
+            ruleset = {
+                "id": "test_provider_stop_timeout",
+                "stop": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request that fails.")
+            with self.assertRaises(TimeoutError):
+                self.logger.info(
+                    "STEP: Verify that the checkin method raises a TimeoutError."
+                )
+                provider.checkin(iut)
+
+    def test_provider_status(self):
+        """Test that the wait method waits for status DONE and exits with response.
+
+        Approvial criteria:
+            - The wait method shall call the status endpoint and return on DONE.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request for a started IUT provider.
+            3. Verify that the wait method returns response on DONE.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        test_id = "123"
+        with FakeServer("ok", {"status": "DONE", "test_id": test_id}) as server:
+            ruleset = {"id": "test_provider_status", "status": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a status request for a started IUT provider.")
+            response = provider.wait("1")
+            self.logger.info(
+                "STEP: Verify that the wait method return response on DONE."
+            )
+            self.assertEqual(response.get("test_id"), test_id)
+
+    def test_provider_status_pending(self):
+        """Test that the wait method waits on status PENDING.
+
+        Approvial criteria:
+            - The wait method shall call the status endpoint, waiting on PENDING.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request for a started IUT provider.
+            3. Verify that the wait method waits on PENDING.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 10)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        responses = [{"status": "PENDING"}, {"status": "PENDING"}, {"status": "DONE"}]
+        with FakeServer("ok", responses.copy()) as server:
+            ruleset = {
+                "id": "test_provider_status_pending",
+                "status": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a status request for a started IUT provider.")
+            provider.wait("1")
+            self.logger.info("STEP: Verify that the wait method waits on PENDING.")
+            self.assertEqual(server.nbr_of_requests, len(responses))
+
+    def test_provider_status_failed(self):
+        """Test that the wait method raises IutCheckoutFailed on FAILED status.
+
+        Approvial criteria:
+            - The wait method shall raise IutCheckoutFailed on a FAILED status.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request for a started IUT provider.
+            3. Verify that the wait method raises IutCheckoutFailed.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        description = "something failed!"
+        with FakeServer(
+            "ok", {"status": "FAILED", "description": description}
+        ) as server:
+            ruleset = {
+                "id": "test_provider_status_failed",
+                "status": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a status request for a started IUT provider.")
+            with self.assertRaises(IutCheckoutFailed):
+                self.logger.info(
+                    "STEP: Verify that the wait method raises IutCheckoutFailed."
+                )
+                provider.wait("1")
+
+    def test_provider_status_http_exceptions(self):
+        """Test that the wait method handles HTTP errors.
+
+        Approvial criteria:
+            - The wait method shall raise IutNotAvailable on 404 errors.
+            - The wait method shall raise RuntimeError on 400 errors.
+
+        Test steps::
+            1. For status [400, 404]:
+                1.1 Initialize an external provider.
+                1.2 Send a status request for a started IUT provider.
+                1.3 Verify that the wait method raises the correct exception.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        self.logger.info("STEP: For status [400, 404]:")
+        for status, exception in (
+            ("bad_request", RuntimeError),
+            ("not_found", IutNotAvailable),
+        ):
+            with FakeServer(status, {"error": "failure"}) as server:
+                ruleset = {
+                    "id": "test_provider_status_http_exceptions",
+                    "status": {"host": server.host},
+                }
+                self.logger.info("STEP: Initialize an external provider.")
+                provider = Provider(etos, jsontas, ruleset)
+                self.logger.info(
+                    "STEP: Send a status request for a started IUT provider."
+                )
+                with self.assertRaises(exception):
+                    self.logger.info(
+                        "STEP: Verify that the wait method raises the correct exception."
+                    )
+                    provider.wait("1")
+
+    def test_provider_status_timeout(self):
+        """Test that the wait method raises TimeoutError when timed out.
+
+        Approvial criteria:
+            - The wait method shall raise TimeoutError when timed out.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request that times out.
+            3. Verify that the wait method raises TimeoutError.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset = {
+            "identity": PackageURL.from_string("pkg:testing/etos"),
+            "artifact_id": "artifactid",
+            "artifact_created": "artifactcreated",
+            "artifact_published": "artifactpublished",
+            "tercc": "tercc",
+            "dataset": {},
+            "context": "context",
+        }
+        with FakeServer("internal_server_error", {}) as server:
+            ruleset = {
+                "id": "test_provider_status_timeout",
+                "status": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a status request that times out.")
+            with self.assertRaises(TimeoutError):
+                self.logger.info(
+                    "STEP: Verify that the wait method raises TimeoutError."
+                )
+                provider.wait("1")
+
+    def test_request_and_wait(self):
+        """Test that the external IUT provider can checkout IUTs.
+
+        Approvial criteria:
+            - The external IUT provider shall request an external provider and checkout IUTs.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a checkout request via the external IUT provider.
+            3. Verify that the provider returns a list of checked out IUTs.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_IUT_TIMEOUT", 10)
+        jsontas = JsonTas()
+        identity = PackageURL.from_string("pkg:testing/etos")
+        jsontas.dataset.merge(
+            {
+                "identity": identity,
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        start_id = "1"
+        test_id = "iut123"
+        provider_id = "test_request_and_wait"
+        # First request is 'start'.
+        # Second request is 'status'.
+        # Third request is 'stop' which should not be requested in this test.
+        with FakeServer(
+            ["ok", "ok", "no_content"],
+            [{"id": start_id}, {"iuts": [{"test_id": test_id}], "status": "DONE"}, {}],
+        ) as server:
+            ruleset = {
+                "id": provider_id,
+                "status": {"host": server.host},
+                "start": {"host": server.host},
+                "stop": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info(
+                "STEP: Send a checkout request via the external IUT provider."
+            )
+            iuts = provider.request_and_wait_for_iuts()
+            self.logger.info(
+                "STEP: Verify that the provider returns a list of checked out IUTs."
+            )
+            dict_iuts = [iut.as_dict for iut in iuts]
+            test_iuts = [
+                Iut(provider_id=provider_id, test_id=test_id, identity=identity).as_dict
+            ]
+            self.assertEqual(dict_iuts, test_iuts)

--- a/tests/external_iut/test_external_iut.py
+++ b/tests/external_iut/test_external_iut.py
@@ -51,15 +51,17 @@ class TestExternalIUT(unittest.TestCase):
         """
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         expected_start_id = "123"
 
         with FakeServer("ok", {"id": expected_start_id}) as server:
@@ -86,15 +88,17 @@ class TestExternalIUT(unittest.TestCase):
         """
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         expected_start_id = "123"
 
         with FakeServer(
@@ -127,15 +131,17 @@ class TestExternalIUT(unittest.TestCase):
         """
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         os.environ["ETOS_DEFAULT_HTTP_TIMEOUT"] = "1"
 
         with FakeServer("bad_request", {}) as server:
@@ -167,15 +173,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         iut = Iut(test_iut=1)
 
         with FakeServer("no_content", {}) as server:
@@ -203,16 +211,18 @@ class TestExternalIUT(unittest.TestCase):
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
         iuts = [Iut(test_iut=1), Iut(test_iut=2)]
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-            "iuts": iuts,
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+                "iuts": iuts,
+            }
+        )
         dict_iuts = [iut.as_dict for iut in iuts]
 
         with FakeServer("no_content", {}) as server:
@@ -239,15 +249,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         iut = Iut(test_iut=1)
 
         with FakeServer("bad_request", {"error": "no"}) as server:
@@ -275,15 +287,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         iut = Iut(test_iut=1)
         with FakeServer("bad_request", {}) as server:
             ruleset = {
@@ -313,15 +327,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         test_id = "123"
         with FakeServer("ok", {"status": "DONE", "test_id": test_id}) as server:
             ruleset = {"id": "test_provider_status", "status": {"host": server.host}}
@@ -348,15 +364,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 10)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         responses = [{"status": "PENDING"}, {"status": "PENDING"}, {"status": "DONE"}]
         with FakeServer("ok", responses.copy()) as server:
             ruleset = {
@@ -384,15 +402,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         description = "something failed!"
         with FakeServer(
             "ok", {"status": "FAILED", "description": description}
@@ -426,15 +446,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         self.logger.info("STEP: For status [400, 404]:")
         for status, exception in (
             ("bad_request", RuntimeError),
@@ -470,15 +492,17 @@ class TestExternalIUT(unittest.TestCase):
         etos = ETOS("testing_etos", "testing_etos", "testing_etos")
         etos.config.set("WAIT_FOR_IUT_TIMEOUT", 1)
         jsontas = JsonTas()
-        jsontas.dataset = {
-            "identity": PackageURL.from_string("pkg:testing/etos"),
-            "artifact_id": "artifactid",
-            "artifact_created": "artifactcreated",
-            "artifact_published": "artifactpublished",
-            "tercc": "tercc",
-            "dataset": {},
-            "context": "context",
-        }
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
         with FakeServer("internal_server_error", {}) as server:
             ruleset = {
                 "id": "test_provider_status_timeout",

--- a/tests/library/__init__.py
+++ b/tests/library/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Library helpers for testing."""

--- a/tests/library/fake_server.py
+++ b/tests/library/fake_server.py
@@ -1,0 +1,131 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A fake server implementation for testing remote requests."""
+import json
+import logging
+from threading import Thread
+import socket
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import requests
+
+# pylint:disable=invalid-name
+
+
+class FakeServer:
+    """A fake server implementation for use in tests."""
+
+    mock_server = None
+    thread = None
+    port = None
+
+    def __init__(self, status_name, response_json):
+        """Initialize server with status name and response json.
+
+        :param status_name: Name of status as defined by :obj:`requests.codes`.
+        :type status_name: str or list
+        :param response_json: A dictionary of JSON response that the fake server shal respond with.
+        :type response_json: dict or list
+        """
+        self.requests = []
+        self.status_name = status_name
+        self.response_json = response_json
+
+    @staticmethod
+    def __free_port():
+        """Figure out a free port for localhost."""
+        sock = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
+        sock.bind(("localhost", 0))
+        _, port = sock.getsockname()
+        sock.close()
+        return port
+
+    @property
+    def host(self):
+        """Host property for this fake server."""
+        return f"http://localhost:{self.port}"
+
+    @property
+    def nbr_of_requests(self):
+        """Total number of requests made to server."""
+        return len(self.requests)
+
+    def store_request(self, request):
+        """Store the request that was made.
+
+        :param request: New request that was received.
+        :type request: dict
+        """
+        self.requests.append(request)
+
+    def __enter__(self):
+        """Figure out free port and start up a fake server in a thread."""
+        self.port = self.__free_port()
+        self.mock_server = HTTPServer(("localhost", self.port), Handler)
+        self.thread = Thread(target=self.mock_server.serve_forever)
+        self.thread.setDaemon(True)
+        self.thread.start()
+        self.mock_server.RequestHandlerClass.parent = self
+        self.mock_server.RequestHandlerClass.response_code = self.status_name
+        self.mock_server.RequestHandlerClass.response_json = self.response_json
+        return self
+
+    def __exit__(self, *_):
+        """Shut down fake server."""
+        self.mock_server.shutdown()
+        self.thread.join()
+
+
+class Handler(BaseHTTPRequestHandler):
+    """HTTP handler for the fake HTTP server."""
+
+    response_json = None
+    response_code = None
+    parent = None
+    logger = logging.getLogger(__name__)
+
+    def do(self):
+        """Handle fake requests to server."""
+        json_string = None
+        try:
+            data_string = self.rfile.read(int(self.headers["Content-Length"]))
+            json_string = json.loads(data_string)
+        except:  # pylint: disable=bare-except
+            pass
+        response = self.response_json
+        status = self.response_code
+        if isinstance(self.response_json, list):
+            response = self.response_json.pop(0)
+        if isinstance(self.response_code, list):
+            status = self.response_code.pop(0)
+        if json_string is not None:
+            self.parent.store_request(json_string)
+        else:
+            self.parent.store_request(self.request)
+        self.send_response(requests.codes[status])
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.end_headers()
+
+        response_content = json.dumps(response)
+        self.wfile.write(response_content.encode("utf-8"))
+
+    def do_GET(self):
+        """Handle GET requests."""
+        self.do()
+
+    def do_POST(self):
+        """Handle POST requests."""
+        self.do()

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist = py3,black,pylint,pydocstyle
 
-# [testenv]
-# deps =
-#     -r{toxinidir}/test-requirements.txt
-# commands =
-#     pytest -s --log-format="%(levelname)s: %(message)s" {posargs}
+[testenv]
+deps =
+    -r{toxinidir}/test-requirements.txt
+commands =
+    pytest -s --log-format="%(levelname)s: %(message)s" {posargs}
 
 [testenv:black]
 deps =
@@ -17,7 +17,7 @@ commands =
 deps =
     pylint
 commands =
-    pylint src/environment_provider tests
+    pylint -d duplicate-code src/environment_provider tests
 
 [testenv:pydocstyle]
 deps =


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#83

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Implemented an external IUT provider service for requesting IUTs from external APIs.
Note that this implementation is done but not tested in real life. It is also not enabled.
We will implement this feature in steps so that the size of the update is smaller.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
There are multiple designs that were considered. The one we use now delegates most of the work to the external provider so that there is more control and less red tape.

### Benefits
<!-- What benefits will be realized by the change? -->
This allows users that need complex JSONTas providers to create a separate service for their work instead. Making it easier to debug and understand what goes wrong.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
There is added complexity in the environment provider until we've done away with or separated out the JSONTas provider code.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
