### PR TITLE
Cleanup subsuite endpoint

### DIFF
--- a/src/environment_provider/backend/subsuite.py
+++ b/src/environment_provider/backend/subsuite.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend services for the sub suite endpoint."""
+import json
+
+import falcon
+
+
+def sub_suite(database, sub_suite_id):
+    """Sub suite gets a sub suite by suite_id from database.
+
+    :param database: The database to get sub suites from.
+    :type database: :obj:`etos_lib.lib.database.Database`
+    :param sub_suite_id: The suite ID of the sub suite in database.
+    :type sub_suite_id: str
+    :return: Sub suite or None.
+    :rtype: dict
+    """
+    suite = database.read(sub_suite_id)
+    if suite is None:
+        return suite
+    return json.loads(suite)
+
+
+def suite_id(request):
+    """Suite ID returns the 'id' parameter from a request.
+
+    :raises: falcon.HTTPBadRequest if ID is missing.
+
+    :param request: The falcon request object.
+    :type request: :obj:`falcon.request`
+    :return: A suite ID from the request.
+    :rtype: str
+    """
+    _id = request.get_param("id")
+    if _id is None:
+        raise falcon.HTTPBadRequest(
+            "Missing parameter", "'id' is a required parameter."
+        )
+    return _id

--- a/src/environment_provider/backend/subsuite.py
+++ b/src/environment_provider/backend/subsuite.py
@@ -19,7 +19,7 @@ import json
 import falcon
 
 
-def sub_suite(database, sub_suite_id):
+def get_sub_suite(database, sub_suite_id):
     """Sub suite gets a sub suite by suite_id from database.
 
     :param database: The database to get sub suites from.
@@ -35,8 +35,8 @@ def sub_suite(database, sub_suite_id):
     return json.loads(suite)
 
 
-def suite_id(request):
-    """Suite ID returns the 'id' parameter from a request.
+def get_id(request):
+    """ID returns the 'id' parameter from a request.
 
     :raises: falcon.HTTPBadRequest if ID is missing.
 

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -56,13 +56,11 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
     task_track_started = True
     lock = Lock()
 
-    def __init__(self, suite_id, database):
+    def __init__(self, suite_id):
         """Initialize ETOS, dataset, provider registry and splitter.
 
         :param suite_id: Suite ID to get an environment for
         :type suite_id: str
-        :param database: Database class to use.
-        :type database: class
         """
         self.suite_id = suite_id
         FORMAT_CONFIG.identifier = suite_id
@@ -394,15 +392,13 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
 
 
 @APP.task(name="EnvironmentProvider")
-def get_environment(suite_id, database):
+def get_environment(suite_id):
     """Get an environment for ETOS test executions.
 
     :param suite_id: Suite ID to get an environment for
     :type suite_id: str
-    :param database: Database class to use.
-    :type database: class
     :return: Test suite JSON with assigned IUTs, execution spaces and log areas.
     :rtype: dict
     """
-    environment_provider = EnvironmentProvider(suite_id, database)
+    environment_provider = EnvironmentProvider(suite_id)
     return environment_provider.run()

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -56,11 +56,13 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
     task_track_started = True
     lock = Lock()
 
-    def __init__(self, suite_id):
+    def __init__(self, suite_id, database):
         """Initialize ETOS, dataset, provider registry and splitter.
 
         :param suite_id: Suite ID to get an environment for
         :type suite_id: str
+        :param database: Database class to use.
+        :type database: class
         """
         self.suite_id = suite_id
         FORMAT_CONFIG.identifier = suite_id
@@ -392,13 +394,15 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
 
 
 @APP.task(name="EnvironmentProvider")
-def get_environment(suite_id):
+def get_environment(suite_id, database):
     """Get an environment for ETOS test executions.
 
     :param suite_id: Suite ID to get an environment for
     :type suite_id: str
+    :param database: Database class to use.
+    :type database: class
     :return: Test suite JSON with assigned IUTs, execution spaces and log areas.
     :rtype: dict
     """
-    environment_provider = EnvironmentProvider(suite_id)
+    environment_provider = EnvironmentProvider(suite_id, database)
     return environment_provider.run()

--- a/src/environment_provider/webserver.py
+++ b/src/environment_provider/webserver.py
@@ -16,7 +16,6 @@
 """ETOS Environment Provider webserver module."""
 import os
 import logging
-import json
 import falcon
 
 from etos_lib.etos import ETOS
@@ -48,9 +47,7 @@ from environment_provider.backend.configure import (
     get_iut_provider_id,
     get_log_area_provider_id,
 )
-from environment_provider.backend.subsuite import (
-    sub_suite as get_sub_suite,
-)
+from environment_provider.backend.subsuite import get_sub_suite, get_id
 from environment_provider.backend.common import get_suite_id
 
 
@@ -266,7 +263,7 @@ class SubSuite:  # pylint:disable=too-few-public-methods
         :param response: Falcon response object.
         :type response: :obj:`falcon.response`
         """
-        suite = get_sub_suite(self.database(), get_suite_id(request))
+        suite = get_sub_suite(self.database(), get_id(request))
         if suite is None:
             raise falcon.HTTPNotFound(
                 title="Sub suite not found.",

--- a/src/environment_provider/webserver.py
+++ b/src/environment_provider/webserver.py
@@ -48,6 +48,9 @@ from environment_provider.backend.configure import (
     get_iut_provider_id,
     get_log_area_provider_id,
 )
+from environment_provider.backend.subsuite import (
+    sub_suite as get_sub_suite,
+)
 from environment_provider.backend.common import get_suite_id
 
 
@@ -255,8 +258,7 @@ class SubSuite:  # pylint:disable=too-few-public-methods
         """
         self.database = database
 
-    @staticmethod
-    def on_get(request, response):
+    def on_get(self, request, response):
         """Get a generated sub suite from environment provider.
 
         :param request: Falcon request object.
@@ -264,21 +266,14 @@ class SubSuite:  # pylint:disable=too-few-public-methods
         :param response: Falcon response object.
         :type response: :obj:`falcon.response`
         """
-        sub_suite_id = request.get_param("id")
-        if sub_suite_id is None:
-            raise falcon.HTTPBadRequest(
-                "Missing parameter", "'id' is a required parameter."
-            )
-        database = Database()
-        sub_suite = database.read(sub_suite_id)
-        if sub_suite:
-            response.status = falcon.HTTP_200
-            response.media = json.loads(sub_suite)
-        else:
+        suite = get_sub_suite(self.database(), get_suite_id(request))
+        if suite is None:
             raise falcon.HTTPNotFound(
                 title="Sub suite not found.",
-                description=f"Could not find sub suite with ID {sub_suite_id}",
+                description=f"Could not find sub suite with ID {get_suite_id(request)}",
             )
+        response.status = falcon.HTTP_200
+        response.media = suite
 
 
 FALCON_APP = falcon.API(middleware=[RequireJSON(), JSONTranslator()])

--- a/tests/backend/test_sub_suite.py
+++ b/tests/backend/test_sub_suite.py
@@ -1,0 +1,107 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the sub suite backend system."""
+import logging
+import unittest
+import json
+
+import falcon
+
+from environment_provider.backend.subsuite import suite_id, sub_suite
+from tests.library.fake_request import FakeRequest
+from tests.library.fake_database import FakeDatabase
+
+
+class TestSubSuiteBackend(unittest.TestCase):
+    """Test the sub suite backend."""
+
+    logger = logging.getLogger(__name__)
+
+    def test_suite_id(self):
+        """Test that the subsuite backend can return suite IDs.
+
+        Approval criteria:
+            - The subsuite backend shall be able to get the suite ID from request parameters.
+
+        Test steps:
+            1. Get Suite ID from request via the suite id function.
+            2. Verify that the suite id function return the correct ID.
+        """
+        request = FakeRequest()
+        test_id = "thisismytestid"
+        request.fake_params["id"] = test_id
+        self.logger.info("STEP: Get Suite ID from request via the suite id function.")
+        response_id = suite_id(request)
+        self.logger.info(
+            "STEP: Verify that the suite id function return the correct ID."
+        )
+        self.assertEqual(test_id, response_id)
+
+    def test_suite_id_missing(self):
+        """Test that the subsuite backend raises bad request if id is missing.
+
+        Approval criteria:
+            - The subsuite backend shall raise falcon.HTTPBadRequest if ID is missing.
+
+        Test steps:
+            1. Get Suite ID from request via the suite id function.
+            2. Verify that the suite id function raises falcon.HTTPBadRequest.
+        """
+        request = FakeRequest()
+        request.fake_params["id"] = None
+        self.logger.info("STEP: Get Suite ID from request via the suite id function.")
+        self.logger.info(
+            "STEP: Verify that the suite id function raises falcon.HTTPBadRequest."
+        )
+        with self.assertRaises(falcon.HTTPBadRequest):
+            suite_id(request)
+
+    def test_sub_suite(self):
+        """Test that the subsuite backend can return the sub suite registered in database.
+
+        Approval criteria:
+            - The subsuite backend shall be able to return sub suites registered in the database.
+
+        Test steps:
+            1. Add a sub suite to the database.
+            2. Get sub suite from the subsuite backend.
+            3. Verify that the sub suite is the one stored in the database.
+        """
+        database = FakeDatabase()
+        self.logger.info("STEP: Add a sub suite to the database.")
+        test_suite = {"testing": "subsuites"}
+        database.write("mysuite", json.dumps(test_suite))
+        self.logger.info("STEP: Get the sub suite from the subsuite backend.")
+        response_suite = sub_suite(database, "mysuite")
+        self.logger.info(
+            "STEP: Verify that the sub suite is the one stored in the database."
+        )
+        self.assertDictEqual(test_suite, response_suite)
+
+    def test_sub_suite_does_not_exist(self):
+        """Test that the subsuite backend return None when there is no sub suite in database.
+
+        Approval criteria:
+            - The subsuite backend shall return None when there is no sub suite in database.
+
+        Test steps:
+            1. Get sub suite from the subsuite backend.
+            2. Verify that the sub suite returned is None.
+        """
+        self.logger.info("STEP: Get the sub suite from the subsuite backend.")
+        suite = sub_suite(FakeDatabase(), 1)
+        self.logger.info("STEP: Verify that the sub suite returned is None.")
+        self.assertIsNone(suite)

--- a/tests/backend/test_sub_suite.py
+++ b/tests/backend/test_sub_suite.py
@@ -20,7 +20,7 @@ import json
 
 import falcon
 
-from environment_provider.backend.subsuite import suite_id, sub_suite
+from environment_provider.backend.subsuite import get_id, get_sub_suite
 from tests.library.fake_request import FakeRequest
 from tests.library.fake_database import FakeDatabase
 
@@ -44,7 +44,7 @@ class TestSubSuiteBackend(unittest.TestCase):
         test_id = "thisismytestid"
         request.fake_params["id"] = test_id
         self.logger.info("STEP: Get Suite ID from request via the suite id function.")
-        response_id = suite_id(request)
+        response_id = get_id(request)
         self.logger.info(
             "STEP: Verify that the suite id function return the correct ID."
         )
@@ -67,7 +67,7 @@ class TestSubSuiteBackend(unittest.TestCase):
             "STEP: Verify that the suite id function raises falcon.HTTPBadRequest."
         )
         with self.assertRaises(falcon.HTTPBadRequest):
-            suite_id(request)
+            get_id(request)
 
     def test_sub_suite(self):
         """Test that the subsuite backend can return the sub suite registered in database.
@@ -85,7 +85,7 @@ class TestSubSuiteBackend(unittest.TestCase):
         test_suite = {"testing": "subsuites"}
         database.write("mysuite", json.dumps(test_suite))
         self.logger.info("STEP: Get the sub suite from the subsuite backend.")
-        response_suite = sub_suite(database, "mysuite")
+        response_suite = get_sub_suite(database, "mysuite")
         self.logger.info(
             "STEP: Verify that the sub suite is the one stored in the database."
         )
@@ -102,6 +102,6 @@ class TestSubSuiteBackend(unittest.TestCase):
             2. Verify that the sub suite returned is None.
         """
         self.logger.info("STEP: Get the sub suite from the subsuite backend.")
-        suite = sub_suite(FakeDatabase(), 1)
+        suite = get_sub_suite(FakeDatabase(), 1)
         self.logger.info("STEP: Verify that the sub suite returned is None.")
         self.assertIsNone(suite)

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -1,0 +1,79 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the webserver and its endpoints."""
+import logging
+import json
+import unittest
+
+import falcon
+
+from environment_provider.webserver import SubSuite
+from tests.library.fake_request import FakeRequest, FakeResponse
+from tests.library.fake_database import FakeDatabase
+
+
+class TestSubSuite(unittest.TestCase):
+    """Tests for the sub suite endpoint."""
+
+    logger = logging.getLogger(__name__)
+
+    def test_get(self):
+        """Test that it is possible to get a sub suite from the sub suite endpoint.
+
+        Approval criteria:
+            - The sub suite endpoint shall return a sub suite if one exists.
+
+        Test steps:
+            1. Add a sub suite to the database.
+            2. Send a fake request to the sub suite endpoint.
+            3. Verify that the sub suite endpoint responds with a sub suite.
+        """
+        self.logger.info("STEP: Add a sub suite to the database.")
+        database = FakeDatabase()
+        suite_id = "thetestiestofsuites"
+        sub_suite = {"test": "suite"}
+        database.write(suite_id, json.dumps(sub_suite))
+
+        self.logger.info("STEP: Send a fake request to the sub suite endpoint.")
+        request = FakeRequest()
+        request.fake_params["id"] = suite_id
+        response = FakeResponse()
+        SubSuite(database).on_get(request, response)
+
+        self.logger.info(
+            "STEP: Verify that the sub suite endpoint responds with a sub suite."
+        )
+        self.assertDictEqual(response.fake_responses.get("media"), sub_suite)
+
+    def test_get_no_id(self):
+        """Test that the sub suite endpoint fails when sub suite was not found.
+
+        Approval criteria:
+            - The sub suite endpoint shall raise a HTTPNotFound exception when no suite is found.
+
+        Test steps:
+            1. Send a fake request to the sub suite endpoint.
+            2. Verify that the sub suite endpoint responds with HTTPNotFound.
+        """
+        self.logger.info("STEP: Send a fake request to the sub suite endpoint.")
+        request = FakeRequest()
+        request.fake_params["id"] = "thisonedoesnotexist"
+        response = FakeResponse()
+        self.logger.info(
+            "STEP: Verify that the sub suite endpoint responds with HTTPNotFound."
+        )
+        with self.assertRaises(falcon.HTTPNotFound):
+            SubSuite(FakeDatabase).on_get(request, response)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#83

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This PR is the first of several clean-up changes that will be created. I do them in steps to make reviewing easier.

This is done in preparation for the external provider change that is on its way ( #38 )
By making the endpoints cleaner, we can make the external provider changes easier.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
There are multiple designs, I chose the one where we

1. Reduce the size of webserver.py the most.
2. Make it easier to test.

### Benefits
<!-- What benefits will be realized by the change? -->
Makes it easier to understand what is going on in the webserver.py file and makes it a lot easier to test.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Some code-jumping will be involved. With proper function naming this will be mitigated.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
