### PR TITLE
Add an external log area provider

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,8 +92,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"environment_provider"
-copyright = u"2020, Axis Communications AB"
+project = "environment_provider"
+copyright = "2020, Axis Communications AB"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -241,7 +241,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "user_guide.tex", u"environment_provider Documentation", u"", "manual"),
+    ("index", "user_guide.tex", "environment_provider Documentation", "", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/src/environment_provider/external_log_area/__init__.py
+++ b/src/environment_provider/external_log_area/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External log area tests."""

--- a/src/environment_provider/external_log_area/provider.py
+++ b/src/environment_provider/external_log_area/provider.py
@@ -1,0 +1,269 @@
+# Copyright 2022 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External log area provider."""
+from json.decoder import JSONDecodeError
+import time
+import logging
+from copy import deepcopy
+
+import requests
+
+from environment_provider.logs.exceptions import (
+    LogAreaCheckinFailed,
+    LogAreaCheckoutFailed,
+    LogAreaNotAvailable,
+)
+from environment_provider.logs.log_area import LogArea
+
+
+class Provider:
+    """A log area provider facility for getting log areas from an external source.
+
+    The ruleset must provide this structure:
+
+    {
+        "status": {
+            "host": "host to status endpoint"
+        },
+        "start": {
+            "host": "host to start endpoint"
+        },
+        "stop": {
+            "host": "host to stop endpoint"
+        }
+    }
+    """
+
+    logger = logging.getLogger("External LogAreaProvider")
+
+    def __init__(self, etos, jsontas, ruleset):
+        """Initialize log area provider.
+
+        :param etos: ETOS library instance.
+        :type etos: :obj:`etos_lib.etos.Etos`
+        :param jsontas: JSONTas instance used to evaluate the rulesets.
+        :type jsontas: :obj:`jsontas.jsontas.JsonTas`
+        :param ruleset: JSONTas ruleset for handling log areas.
+        :type ruleset: dict
+        """
+        self.etos = etos
+        self.etos.config.set("logs", [])
+        self.dataset = jsontas.dataset
+        self.ruleset = ruleset
+        self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.logger.info("Initialized external log area provider %r", self.id)
+
+    @property
+    def identity(self):
+        """IUT identity.
+
+        :return: IUT identity as PURL object.
+        :rtype: :obj:`packageurl.PackageURL`
+        """
+        return self.dataset.get("identity")
+
+    def checkin(self, log_area):
+        """Check in log areas.
+
+        :param log_area: Log area to check in.
+        :type log_area: :obj:`environment_provider.logs.log_area.LogArea` or list
+        """
+        end = self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
+
+        if not isinstance(log_area, list):
+            self.logger.debug("Check in log area %r (timeout %ds)", log_area, end)
+            log_area = [log_area]
+        else:
+            self.logger.debug("Check in log areas %r (timeout %ds)", log_area, end)
+        log_areas = [log_area.as_dict for log_area in log_area]
+
+        host = self.ruleset.get("stop", {}).get("host")
+        timeout = time.time() + end
+        while time.time() < timeout:
+            time.sleep(2)
+            try:
+                response = requests.post(host, json=log_areas)
+                if response.status_code == requests.codes["no_content"]:
+                    return
+                response = response.json()
+                if response.get("error") is not None:
+                    raise LogAreaCheckinFailed(
+                        f"Unable to check in {log_areas} " r"({response.get('error')})"
+                    )
+            except ConnectionError:
+                self.logger.error("Error connecting to %r", host)
+                continue
+        raise TimeoutError(f"Unable to stop external provider {self.id!r}")
+
+    def checkin_all(self):
+        """Check in all log areas.
+
+        This method does the same as 'checkin'. It exists for API consistency.
+        """
+        self.logger.debug("Checking in all checked out log areas")
+        self.checkin(self.dataset.get("logs", []))
+
+    def start(self, minimum_amount, maximum_amount):
+        """Send a start request to an external log area provider.
+
+        :param minimum_amount: Minimum amount of log areas to request.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of log areas to request.
+        :type maximum_amount: int
+        :return: The ID of the external log area provider request.
+        :rtype: str
+        """
+        self.logger.debug("Start external log area provider")
+        data = {
+            "minimum_amount": minimum_amount,
+            "maximum_amount": maximum_amount,
+            "identity": self.identity.to_string(),
+            "artifact_id": self.dataset.get("artifact_id"),
+            "artifact_created": self.dataset.get("artifact_created"),
+            "artifact_published": self.dataset.get("artifact_published"),
+            "tercc": self.dataset.get("tercc"),
+            "dataset": self.dataset.get("dataset"),
+            "context": self.dataset.get("context"),
+        }
+        response_iterator = self.etos.http.retry(
+            "POST",
+            self.ruleset.get("start", {}).get("host"),
+            json=data,
+        )
+        try:
+            for response in response_iterator:
+                return response.get("id")
+        except ConnectionError as http_error:
+            self.logger.error(
+                "Could not start external provider due to a connection error"
+            )
+            raise TimeoutError(
+                f"Unable to start external provider {self.id!r}"
+            ) from http_error
+        raise TimeoutError(f"Unable to start external provider {self.id!r}")
+
+    def wait(self, provider_id):
+        """Wait for external log area provider to finish its request.
+
+        :param provider_id: The ID of the external log area provider request.
+        :type provider_id: str
+        :return: The response from the external log area provider.
+        :rtype: dict
+        """
+        self.logger.debug(
+            "Waiting for external log area provider (%ds timeout)",
+            self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT"),
+        )
+
+        host = self.ruleset.get("status", {}).get("host")
+        timeout = time.time() + self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
+
+        response = None
+        while time.time() < timeout:
+            time.sleep(2)
+            try:
+                response = requests.get(host, params={"id": provider_id})
+                self.check_error(response)
+                response = response.json()
+            except ConnectionError:
+                self.logger.error("Error connecting to %r", host)
+                continue
+
+            if response.get("status") == "FAILED":
+                raise LogAreaCheckoutFailed(response.get("description"))
+            if response.get("status") == "DONE":
+                break
+        else:
+            raise TimeoutError(
+                "Status request timed out after "
+                f"{self.etos.config.get('WAIT_FOR_LOG_AREA_TIMEOUT')}s"
+            )
+        return response
+
+    def check_error(self, response):
+        """Check response for errors and try to translate them to something usable.
+
+        :param response: The response from the external log area provider.
+        :type response: dict
+        """
+        self.logger.debug("Checking response from external log area provider")
+        try:
+            if response.json().get("error") is not None:
+                self.logger.error(response.json().get("error"))
+        except JSONDecodeError:
+            self.logger.error("Could not parse response as JSON")
+
+        if response.status_code == requests.codes["not_found"]:
+            raise LogAreaNotAvailable(
+                f"External provider {self.id!r} did not respond properly"
+            )
+        if response.status_code == requests.codes["bad_request"]:
+            raise RuntimeError(
+                f"Log area provider for {self.id!r} is not properly configured"
+            )
+
+        # This should work, no other errors found.
+        # If this does not work, propagate JSONDecodeError up the stack.
+        self.logger.debug("Status for response %r", response.json().get("status"))
+
+    def build_log_areas(self, response):
+        """Build log area objects from external log area provider response.
+
+        :param response: The response from the external log area provider.
+        :type response: dict
+        :return: A list of log areas.
+        :rtype: list
+        """
+        return [
+            LogArea(provider_id=self.id, **log_area)
+            for log_area in response.get("log_areas", [])
+        ]
+
+    def request_and_wait_for_log_areas(self, minimum_amount=0, maximum_amount=100):
+        """Wait for log areas from an external log area provider.
+
+        :raises: LogAreaNotAvailable: If there are not available log areas after timeout.
+
+        :param minimum_amount: Minimum amount of log areas to checkout.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of log areas to checkout.
+        :type maximum_amount: int
+        :return: List of checked out log areas.
+        :rtype: list
+        """
+        try:
+            provider_id = self.start(minimum_amount, maximum_amount)
+            response = self.wait(provider_id)
+            log_areas = self.build_log_areas(response)
+            if len(log_areas) < minimum_amount:
+                raise LogAreaNotAvailable(self.id)
+            if len(log_areas) > maximum_amount:
+                self.logger.warning(
+                    "Too many log areas from external log area provider "
+                    "%r. (Expected: %d, Got %d)",
+                    self.id,
+                    maximum_amount,
+                    len(log_areas),
+                )
+                extra = log_areas[maximum_amount:]
+                log_areas = log_areas[:maximum_amount]
+                for log_area in extra:
+                    self.checkin(log_area)
+            self.dataset.add("logs", deepcopy(log_areas))
+        except:  # pylint:disable=bare-except
+            self.checkin_all()
+            raise
+        return log_areas

--- a/tests/external_log_area/__init__.py
+++ b/tests/external_log_area/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External log area provider tests."""

--- a/tests/external_log_area/test_external_log_area.py
+++ b/tests/external_log_area/test_external_log_area.py
@@ -1,0 +1,594 @@
+# Copyright 2022 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for the external log area."""
+import os
+import logging
+import unittest
+
+from etos_lib import ETOS
+from jsontas.jsontas import JsonTas
+from packageurl import PackageURL
+
+from tests.library.fake_server import FakeServer
+
+from environment_provider.external_log_area.provider import Provider
+from environment_provider.logs.exceptions import (
+    LogAreaCheckinFailed,
+    LogAreaCheckoutFailed,
+    LogAreaNotAvailable,
+)
+from environment_provider.logs.log_area import LogArea
+
+
+class TestExternalLogArea(unittest.TestCase):
+    """Test the external log area provider."""
+
+    logger = logging.getLogger(__name__)
+
+    def tearDown(self):
+        """Re-set the default HTTP timeout."""
+        os.environ["ETOS_DEFAULT_HTTP_TIMEOUT"] = "3600"
+
+    def test_provider_start(self):
+        """Test that it is possible to start an external log area provider.
+
+        Approval criteria:
+            - It shall be possible to send start to an external log area provider.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a start request.
+            3. Verify that the ID from the start request is returned.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        expected_start_id = "123"
+
+        with FakeServer("ok", {"id": expected_start_id}) as server:
+            ruleset = {"id": "test_provider_start", "start": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a start request.")
+            start_id = provider.start(1, 2)
+            self.logger.info(
+                "STEP: Verify that the ID from the start request is returned."
+            )
+            self.assertEqual(start_id, expected_start_id)
+
+    def test_provider_start_http_exception(self):
+        """Test that the start method tries again if there's an HTTP error.
+
+        Approval criteria:
+            - The start method shall try again on HTTP errors.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a start request that fails.
+            3. Verify that the start method tries again on HTTP errors.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        expected_start_id = "123"
+
+        with FakeServer(
+            ["bad_request", "ok"], [{}, {"id": expected_start_id}]
+        ) as server:
+            ruleset = {
+                "id": "test_provider_start_http_exception",
+                "start": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a start request that fails.")
+            start_id = provider.start(1, 2)
+            self.logger.info(
+                "STEP: Verify that the start method tries again on HTTP errors."
+            )
+            self.assertGreaterEqual(server.nbr_of_requests, 2)
+            self.assertEqual(start_id, expected_start_id)
+
+    def test_provider_start_timeout(self):
+        """Test that the start method raises a TimeoutError.
+
+        Approval criteria:
+            - The start method shall raise TimeoutError if the timeout is reached.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a start request which will never finish.
+            3. Verify that the start method raises TimeoutError.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        os.environ["ETOS_DEFAULT_HTTP_TIMEOUT"] = "1"
+
+        with FakeServer("bad_request", {}) as server:
+            ruleset = {
+                "id": "test_provider_start_timeout",
+                "start": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a start request which will never finish.")
+
+            with self.assertRaises(TimeoutError):
+                self.logger.info(
+                    "STEP: Verify that the start method raises TimeoutError."
+                )
+                provider.start(1, 2)
+
+    def test_provider_stop(self):
+        """Test that it is possible to checkin an external log area provider.
+
+        Approval criteria:
+            - It shall be possible to send stop to an external log area provider.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request for a single log area.
+            3. Verify that the stop endpoint is called.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        log_area = LogArea(test_log_area=1)
+
+        with FakeServer("no_content", {}) as server:
+            ruleset = {"id": "test_provider_stop", "stop": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request for a single log area.")
+            provider.checkin(log_area)
+            self.logger.info("STEP: Verify that the stop endpoint is called.")
+            self.assertEqual(server.nbr_of_requests, 1)
+            self.assertEqual(server.requests, [[log_area.as_dict]])
+
+    def test_provider_stop_many(self):
+        """Test that it is possible to checkin an external log area provider with many
+           log areas.
+
+        Approval criteria:
+            - It shall be possible to send stop to an external log area provider
+              with multiple log areas.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request for multiple log areas.
+            3. Verify that the stop endpoint is called.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        log_areas = [
+            LogArea(test_log_area=1),
+            LogArea(test_log_area=2),
+        ]
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+                "logs": log_areas,
+            }
+        )
+        dict_log_areas = [log_area.as_dict for log_area in log_areas]
+
+        with FakeServer("no_content", {}) as server:
+            ruleset = {"id": "test_provider_stop_many", "stop": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request for multiple log areas.")
+            provider.checkin_all()
+            self.logger.info("STEP: Verify that the stop endpoint is called.")
+            self.assertEqual(server.nbr_of_requests, 1)
+            self.assertEqual(server.requests, [dict_log_areas])
+
+    def test_provider_stop_failed(self):
+        """Test that the checkin method raises an LogAreaCheckinFailed exception.
+
+        Approval criteria:
+            - The checkin method shall fail with an LogAreaCheckinFailed exception.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request that fails.
+            3. Verify that the checkin method raises LogAreaCheckinFailed exception.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        log_area = LogArea(test_log_area=1)
+
+        with FakeServer("bad_request", {"error": "no"}) as server:
+            ruleset = {"id": "test_provider_stop_failed", "stop": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request that fails.")
+            with self.assertRaises(LogAreaCheckinFailed):
+                self.logger.info(
+                    "STEP: Verify that the checkin method raises LogAreaCheckinFailed "
+                    "exception."
+                )
+                provider.checkin(log_area)
+
+    def test_provider_stop_timeout(self):
+        """Test that the checkin method raises a TimeoutError when timed out.
+
+        Approval criteria:
+            - The checkin method shall raise TimeoutError when timed out.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a stop request for log areas that times out.
+            3. Verify that the checkin method raises a TimeoutError.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        log_area = LogArea(test_log_area=1)
+        with FakeServer("bad_request", {}) as server:
+            ruleset = {
+                "id": "test_provider_stop_timeout",
+                "stop": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a stop request that fails.")
+            with self.assertRaises(TimeoutError):
+                self.logger.info(
+                    "STEP: Verify that the checkin method raises a TimeoutError."
+                )
+                provider.checkin(log_area)
+
+    def test_provider_status(self):
+        """Test that the wait method waits for status DONE and exits with response.
+
+        Approvial criteria:
+            - The wait method shall call the status endpoint and return on DONE.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request for a started log area provider.
+            3. Verify that the wait method returns response on DONE.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        test_id = "123"
+        with FakeServer("ok", {"status": "DONE", "test_id": test_id}) as server:
+            ruleset = {"id": "test_provider_status", "status": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info(
+                "STEP: Send a status request for a started log area provider."
+            )
+            response = provider.wait("1")
+            self.logger.info(
+                "STEP: Verify that the wait method return response on DONE."
+            )
+            self.assertEqual(response.get("test_id"), test_id)
+
+    def test_provider_status_pending(self):
+        """Test that the wait method waits on status PENDING.
+
+        Approvial criteria:
+            - The wait method shall call the status endpoint, waiting on PENDING.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request for a started log area provider.
+            3. Verify that the wait method waits on PENDING.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 10)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        responses = [{"status": "PENDING"}, {"status": "PENDING"}, {"status": "DONE"}]
+        with FakeServer("ok", responses.copy()) as server:
+            ruleset = {
+                "id": "test_provider_status_pending",
+                "status": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info(
+                "STEP: Send a status request for a started log area provider."
+            )
+            provider.wait("1")
+            self.logger.info("STEP: Verify that the wait method waits on PENDING.")
+            self.assertEqual(server.nbr_of_requests, len(responses))
+
+    def test_provider_status_failed(self):
+        """Test that the wait method raises LogAreaCheckoutFailed on FAILED status.
+
+        Approvial criteria:
+            - The wait method shall raise LogAreaCheckoutFailed on a FAILED status.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request for a started log area provider.
+            3. Verify that the wait method raises LogAreaCheckoutFailed.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        description = "something failed!"
+        with FakeServer(
+            "ok", {"status": "FAILED", "description": description}
+        ) as server:
+            ruleset = {
+                "id": "test_provider_status_failed",
+                "status": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info(
+                "STEP: Send a status request for a started log area provider."
+            )
+            with self.assertRaises(LogAreaCheckoutFailed):
+                self.logger.info(
+                    "STEP: Verify that the wait method raises LogAreaCheckoutFailed."
+                )
+                provider.wait("1")
+
+    def test_provider_status_http_exceptions(self):
+        """Test that the wait method handles HTTP errors.
+
+        Approvial criteria:
+            - The wait method shall raise LogAreaNotAvailable on 404 errors.
+            - The wait method shall raise RuntimeError on 400 errors.
+
+        Test steps::
+            1. For status [400, 404]:
+                1.1 Initialize an external provider.
+                1.2 Send a status request for a started log area provider.
+                1.3 Verify that the wait method raises the correct exception.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        self.logger.info("STEP: For status [400, 404]:")
+        for status, exception in (
+            ("bad_request", RuntimeError),
+            ("not_found", LogAreaNotAvailable),
+        ):
+            with FakeServer(status, {"error": "failure"}) as server:
+                ruleset = {
+                    "id": "test_provider_status_http_exceptions",
+                    "status": {"host": server.host},
+                }
+                self.logger.info("STEP: Initialize an external provider.")
+                provider = Provider(etos, jsontas, ruleset)
+                self.logger.info(
+                    "STEP: Send a status request for a started log area provider."
+                )
+                with self.assertRaises(exception):
+                    self.logger.info(
+                        "STEP: Verify that the wait method raises the correct exception."
+                    )
+                    provider.wait("1")
+
+    def test_provider_status_timeout(self):
+        """Test that the wait method raises TimeoutError when timed out.
+
+        Approvial criteria:
+            - The wait method shall raise TimeoutError when timed out.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a status request that times out.
+            3. Verify that the wait method raises TimeoutError.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 1)
+        jsontas = JsonTas()
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        with FakeServer("internal_server_error", {}) as server:
+            ruleset = {
+                "id": "test_provider_status_timeout",
+                "status": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info("STEP: Send a status request that times out.")
+            with self.assertRaises(TimeoutError):
+                self.logger.info(
+                    "STEP: Verify that the wait method raises TimeoutError."
+                )
+                provider.wait("1")
+
+    def test_request_and_wait(self):
+        """Test that the external log area provider can checkout log areas.
+
+        Approval criteria:
+            - The external log area provider shall request an external provider and
+              checkout log areas.
+
+        Test steps::
+            1. Initialize an external provider.
+            2. Send a checkout request via the external log area provider.
+            3. Verify that the provider returns a list of checked out log areas.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("WAIT_FOR_LOG_AREA_TIMEOUT", 10)
+        jsontas = JsonTas()
+        identity = PackageURL.from_string("pkg:testing/etos")
+        jsontas.dataset.merge(
+            {
+                "identity": identity,
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+            }
+        )
+        start_id = "1"
+        test_id = "logarea123"
+        provider_id = "test_request_and_wait"
+        # First request is 'start'.
+        # Second request is 'status'.
+        # Third request is 'stop' which should not be requested in this test.
+        with FakeServer(
+            ["ok", "ok", "no_content"],
+            [
+                {"id": start_id},
+                {"log_areas": [{"test_id": test_id}], "status": "DONE"},
+                {},
+            ],
+        ) as server:
+            ruleset = {
+                "id": provider_id,
+                "status": {"host": server.host},
+                "start": {"host": server.host},
+                "stop": {"host": server.host},
+            }
+            self.logger.info("STEP: Initialize an external provider.")
+            provider = Provider(etos, jsontas, ruleset)
+            self.logger.info(
+                "STEP: Send a checkout request via the external log area provider."
+            )
+            log_areas = provider.request_and_wait_for_log_areas()
+            self.logger.info(
+                "STEP: Verify that the provider returns a list of checked out log areas."
+            )
+            dict_log_areas = [log_area.as_dict for log_area in log_areas]
+            test_log_areas = [LogArea(provider_id=provider_id, test_id=test_id).as_dict]
+            self.assertEqual(dict_log_areas, test_log_areas)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#83

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This provider is unused at the moment and more or less a copy of the external IUT provider.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We might want to look into merging all external provider constructs later, if we don't have any big differences.
The reason I did not do that in this PR is because when we start testing these new providers, we might find issues that only have to be fixed in a specific provider.

### Benefits
<!-- What benefits will be realized by the change? -->
Allows users to create complex providers without writing crazy JSONTas code.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
