### PR TITLE
Make sure to never assign 0 IUTs to a testrunner.

### DIFF
--- a/src/environment_provider/splitter/split.py
+++ b/src/environment_provider/splitter/split.py
@@ -82,6 +82,9 @@ class Splitter:
                 self.etos.config.get("NUMBER_OF_IUTS")
                 * test_runner["percentage_of_tests"]
             )
+            if not number_of_iuts:
+                number_of_iuts = 1
+
             number_of_tests = len(test_runner.get("unsplit_recipes"))
             number_of_iuts = (
                 number_of_tests if number_of_tests < number_of_iuts else number_of_iuts

--- a/tests/splitter/test_splitter.py
+++ b/tests/splitter/test_splitter.py
@@ -1,0 +1,42 @@
+import logging
+import unittest
+
+from etos_lib import ETOS
+from environment_provider.splitter.split import Splitter
+
+
+class TestSplitter(unittest.TestCase):
+    """Test the environment provider slitter."""
+
+    logger = logging.getLogger(__name__)
+
+    def test_assign_iuts(self) -> None:
+        """Test that that a test runner never gets 0 number of IUTs assigned.
+
+        Approval criteria:
+            - A test runner shall never had 0 number of IUTs assigned.
+
+        Test steps::
+            1. Assign IUTs to the provided test runners.
+            2. Verify that no test runner get 0 assigned IUTs.
+        """
+        iuts = ["iut1", "iut2"]
+        test_runners = {
+            "runner1": {"iuts": {}, "unsplit_recipes": [1]},
+            "runner2": {"iuts": {}, "unsplit_recipes": [2, 3, 4, 5]},
+        }
+
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        etos.config.set("TOTAL_TEST_COUNT", 5)
+        etos.config.set("NUMBER_OF_IUTS", len(iuts))
+
+        self.logger.info("STEP: Assign IUTs to the provided test runners.")
+        _ = Splitter(etos, {}).assign_iuts(test_runners, iuts)
+
+        self.logger.info("STEP: Verify that no test runner get 0 assigned IUTs.")
+        for test_runner in test_runners.values():
+            self.assertNotEqual(
+                test_runner.get("number_of_iuts"),
+                0,
+                f"'number_of_iuts' is 0, test_runner got 0 assigned IUTs. {test_runner}]",
+            )

--- a/tests/splitter/test_splitter.py
+++ b/tests/splitter/test_splitter.py
@@ -1,3 +1,19 @@
+# Copyright 2022 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for the environment provider splitter."""
 import logging
 import unittest
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
eiffel-community/etos#130

### Description of the Change
Make sure we always assign at least 1 IUT per testrunner.

### Alternate Designs
You could probably work someting into the whole tound expression but a simple if 0 then 1 was simpler.

### Benefits
A working environment provider

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
