### PR TITLE
Add activity events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/*
 .cache/*
 .*.swp
 */.ipynb_checkpoints/*
+*.tags
 .DS_Store
 
 # Project files

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
 	pyopenssl==19.1.0
 	eventlet==0.26.1
+	greenlet==1.1.3
 	celery==4.4.7
 	gevent==20.9.0
 	gunicorn==19.9.0

--- a/src/environment_provider/lib/graphql.py
+++ b/src/environment_provider/lib/graphql.py
@@ -140,3 +140,38 @@ def request_artifact_published(etos, artifact_id):
         if response:
             return response
     return None
+
+
+def request_main_suite(etos, main_suite_id):
+    """Request a test suite started event from graphql.
+
+    :param etos: ETOS library instance.
+    :type etos: :obj:`etos_lib.etos.Etos`
+    :param main_suite_id: ID of main suite to get from ER.
+    :type main_suite_id: str
+    :return: Response from graphql or None
+    :rtype: dict or None
+    """
+    query = """
+{
+  testSuiteStarted(last: 1, search: "{'meta.id': '%s'}") {
+    edges {
+      node {
+        meta {
+          id
+        }
+      }
+    }
+  }
+}
+    """
+    for response in request(etos, query % main_suite_id):
+        if response:
+            try:
+                _, test_suite_started = next(
+                    etos.graphql.search_for_nodes(response, "testSuiteStarted")
+                )
+            except StopIteration:
+                return None
+            return test_suite_started
+    return None

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -323,7 +323,7 @@ class ExternalProvider:
         triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
-                self.id,
+                f"Checkout execution spaces from {self.id}",
                 {"CONTEXT": self.context},
                 executionType="AUTOMATED",
                 categories=[

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -319,6 +319,7 @@ class ExternalProvider:
         :rtype: list
         """
         error = None
+        triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
                 self.id,
@@ -348,4 +349,5 @@ class ExternalProvider:
                 outcome = {"conclusion": "SUCCESSFUL"}
             else:
                 outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
-            self.etos.events.send_activity_finished(triggered, outcome)
+            if triggered is not None:
+                self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -65,6 +65,7 @@ class ExternalProvider:
         self.dataset = jsontas.dataset
         self.ruleset = ruleset
         self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.context = self.etos.config.get("environment_provider_context")
         self.identifier = self.etos.config.get("SUITE_ID")
         self.logger.info("Initialized external execution space provider %r", self.id)
 

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -301,5 +301,51 @@ class ExternalProvider:
             raise
         return execution_spaces
 
-    # Compatibility with the JSONTas providers.
-    wait_for_and_checkout_execution_spaces = request_and_wait_for_execution_spaces
+    def wait_for_and_checkout_execution_spaces(
+        self, minimum_amount=0, maximum_amount=100
+    ):
+        """Wait for execution spaces from an external execution space provider.
+
+        See: `request_and_wait_for_execution_spaces`
+
+        :raises: ExecutionSpaceNotAvailable: If there are no available execution spaces after
+                                             timeout.
+
+        :param minimum_amount: Minimum amount of execution spaces to checkout.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of execution spaces to checkout.
+        :type maximum_amount: int
+        :return: List of checked out execution spaces.
+        :rtype: list
+        """
+        error = None
+        try:
+            triggered = self.etos.events.send_activity_triggered(
+                self.id,
+                {"CONTEXT": self.context},
+                executionType="AUTOMATED",
+                categories=[
+                    "EnvironmentProvider",
+                    "ExecutionSpaceProvider",
+                    "External",
+                ],
+                triggers=[
+                    {
+                        "type": "OTHER",
+                        "description": f"Checking out execution spaces",
+                    }
+                ],
+            )
+            self.etos.events.send_activity_started(triggered)
+            return self.request_and_wait_for_execution_spaces(
+                minimum_amount, maximum_amount
+            )
+        except Exception as exception:
+            error = exception
+            raise
+        finally:
+            if error is None:
+                outcome = {"conclusion": "SUCCESSFUL"}
+            else:
+                outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
+            self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/execution_space_provider/utilities/jsontas_provider.py
+++ b/src/execution_space_provider/utilities/jsontas_provider.py
@@ -178,7 +178,7 @@ class JSONTasProvider:
         triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
-                self.id,
+                f"Checkout execution spaces from {self.id}",
                 {"CONTEXT": self.context},
                 executionType="AUTOMATED",
                 categories=["EnvironmentProvider", "ExecutionSpaceProvider"],

--- a/src/execution_space_provider/utilities/jsontas_provider.py
+++ b/src/execution_space_provider/utilities/jsontas_provider.py
@@ -47,6 +47,7 @@ class JSONTasProvider:
         self.etos.config.set("execution_spaces", [])
         self.ruleset = ruleset
         self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.context = self.etos.config.get("environment_provider_context")
         self.logger.info("Initialized execution space provider %r", self.id)
 
     def checkout(self, available_execution_spaces):
@@ -88,7 +89,7 @@ class JSONTasProvider:
         checkin_execution_spaces = Checkin(self.jsontas, self.ruleset.get("checkin"))
         checkin_execution_spaces.checkin(execution_space)
 
-    def wait_for_and_checkout_execution_spaces(
+    def _wait_for_and_checkout_execution_spaces(
         self, minimum_amount=0, maximum_amount=100
     ):
         """Wait for and checkout execution spaces from an execution space provider.
@@ -155,3 +156,48 @@ class JSONTasProvider:
         if len(checked_out_execution_spaces) < minimum_amount:
             raise ExecutionSpaceNotAvailable(self.id)
         return checked_out_execution_spaces
+
+    def wait_for_and_checkout_execution_spaces(
+        self, minimum_amount=0, maximum_amount=100
+    ):
+        """Wait for and checkout execution spaces from an execution space provider.
+
+        See: `_wait_for_and_checkout_execution_spaces`
+
+        :raises: ExecutionSpaceNotAvailable: If there are no available execution spaces after
+                                             timeout.
+
+        :param minimum_amount: Minimum amount of execution spaces to checkout.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of execution spaces to checkout.
+        :type maximum_amount: int
+        :return: List of checked out execution spaces.
+        :rtype: list
+        """
+        error = None
+        try:
+            triggered = self.etos.events.send_activity_triggered(
+                self.id,
+                {"CONTEXT": self.context},
+                executionType="AUTOMATED",
+                categories=["EnvironmentProvider", "ExecutionSpaceProvider"],
+                triggers=[
+                    {
+                        "type": "OTHER",
+                        "description": f"Checking out execution spaces",
+                    }
+                ],
+            )
+            self.etos.events.send_activity_started(triggered)
+            return self._wait_for_and_checkout_execution_spaces(
+                minimum_amount, maximum_amount
+            )
+        except Exception as exception:
+            error = exception
+            raise
+        finally:
+            if error is None:
+                outcome = {"conclusion": "SUCCESSFUL"}
+            else:
+                outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
+            self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/execution_space_provider/utilities/jsontas_provider.py
+++ b/src/execution_space_provider/utilities/jsontas_provider.py
@@ -175,6 +175,7 @@ class JSONTasProvider:
         :rtype: list
         """
         error = None
+        triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
                 self.id,
@@ -200,4 +201,5 @@ class JSONTasProvider:
                 outcome = {"conclusion": "SUCCESSFUL"}
             else:
                 outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
-            self.etos.events.send_activity_finished(triggered, outcome)
+            if triggered is not None:
+                self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/iut_provider/utilities/external_provider.py
+++ b/src/iut_provider/utilities/external_provider.py
@@ -308,7 +308,7 @@ class ExternalProvider:
         triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
-                self.id,
+                f"Checkout IUTs from {self.id}",
                 {"CONTEXT": self.context},
                 executionType="AUTOMATED",
                 categories=["EnvironmentProvider", "IUTProvider", "External"],

--- a/src/iut_provider/utilities/external_provider.py
+++ b/src/iut_provider/utilities/external_provider.py
@@ -304,6 +304,7 @@ class ExternalProvider:
         :rtype: list
         """
         error = None
+        triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
                 self.id,
@@ -327,4 +328,5 @@ class ExternalProvider:
                 outcome = {"conclusion": "SUCCESSFUL"}
             else:
                 outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
-            self.etos.events.send_activity_finished(triggered, outcome)
+            if triggered is not None:
+                self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/iut_provider/utilities/external_provider.py
+++ b/src/iut_provider/utilities/external_provider.py
@@ -66,6 +66,7 @@ class ExternalProvider:
         self.dataset = jsontas.dataset
         self.ruleset = ruleset
         self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.context = self.etos.config.get("environment_provider_context")
         self.identifier = self.etos.config.get("SUITE_ID")
         self.logger.info("Initialized external IUT provider %r", self.id)
 

--- a/src/iut_provider/utilities/jsontas_provider.py
+++ b/src/iut_provider/utilities/jsontas_provider.py
@@ -48,6 +48,7 @@ class JSONTasProvider:
         self.jsontas = jsontas
         self.ruleset = ruleset
         self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.context = self.etos.config.get("environment_provider_context")
         self.logger.info("Initialized IUT provider %r", self.id)
 
     @property
@@ -125,7 +126,7 @@ class JSONTasProvider:
         return f"Failed to checkout {self.identity.to_string()}. Reason: {fail_reason}"
 
     # pylint: disable=too-many-branches
-    def wait_for_and_checkout_iuts(self, minimum_amount=0, maximum_amount=100):
+    def _wait_for_and_checkout_iuts(self, minimum_amount=0, maximum_amount=100):
         """Wait for and checkout IUTs from an IUT provider.
 
         :raises: IutNotAvailable: If there are no available IUTs after timeout.
@@ -208,3 +209,43 @@ class JSONTasProvider:
         if len(prepared_iuts) < minimum_amount:
             raise IutNotAvailable(self._fail_message(last_exception))
         return prepared_iuts
+
+    def wait_for_and_checkout_iuts(self, minimum_amount=0, maximum_amount=100):
+        """Wait for and checkout IUTs from an IUT provider.
+
+        See: `_wait_for_and_checkout_iuts`
+
+        :raises: IutNotAvailable: If there are no available IUTs after timeout.
+
+        :param minimum_amount: Minimum amount of IUTs to checkout.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of IUTs to checkout.
+        :type maximum_amount: int
+        :return: List of checked out IUTs.
+        :rtype: list
+        """
+        error = None
+        try:
+            triggered = self.etos.events.send_activity_triggered(
+                self.id,
+                {"CONTEXT": self.context},
+                executionType="AUTOMATED",
+                categories=["EnvironmentProvider", "IUTProvider"],
+                triggers=[
+                    {
+                        "type": "OTHER",
+                        "description": f"Checking out IUTs",
+                    }
+                ],
+            )
+            self.etos.events.send_activity_started(triggered)
+            return self._wait_for_and_checkout_iuts(minimum_amount, maximum_amount)
+        except Exception as exception:
+            error = exception
+            raise
+        finally:
+            if error is None:
+                outcome = {"conclusion": "SUCCESSFUL"}
+            else:
+                outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
+            self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/iut_provider/utilities/jsontas_provider.py
+++ b/src/iut_provider/utilities/jsontas_provider.py
@@ -225,9 +225,10 @@ class JSONTasProvider:
         :rtype: list
         """
         error = None
+        triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
-                self.id,
+                f"Checkout IUTs from {self.id}",
                 {"CONTEXT": self.context},
                 executionType="AUTOMATED",
                 categories=["EnvironmentProvider", "IUTProvider"],
@@ -248,4 +249,5 @@ class JSONTasProvider:
                 outcome = {"conclusion": "SUCCESSFUL"}
             else:
                 outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
-            self.etos.events.send_activity_finished(triggered, outcome)
+            if triggered is not None:
+                self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/iut_provider/utilities/prepare.py
+++ b/src/iut_provider/utilities/prepare.py
@@ -100,7 +100,8 @@ class Prepare:  # pylint:disable=too-few-public-methods
                 self.logger.info("Preparing IUT %r", iut)
                 results.append(
                     thread_pool.apply_async(
-                        self.execute_preparation_steps, args=(iut, deepcopy(steps))
+                        self.execute_preparation_steps,
+                        args=(iut, deepcopy(steps)),
                     )
                 )
             for result in results:

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -65,6 +65,7 @@ class ExternalProvider:
         self.dataset = jsontas.dataset
         self.ruleset = ruleset
         self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.context = self.etos.config.get("environment_provider_context")
         self.identifier = self.etos.config.get("SUITE_ID")
         self.logger.info("Initialized external log area provider %r", self.id)
 

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -305,6 +305,7 @@ class ExternalProvider:
         :rtype: list
         """
         error = None
+        triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
                 self.id,
@@ -328,4 +329,5 @@ class ExternalProvider:
                 outcome = {"conclusion": "SUCCESSFUL"}
             else:
                 outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
-            self.etos.events.send_activity_finished(triggered, outcome)
+            if triggered is not None:
+                self.etos.events.send_activity_finished(triggered, outcome)

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -309,7 +309,7 @@ class ExternalProvider:
         triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
-                self.id,
+                f"Checkout log areas from {self.id}",
                 {"CONTEXT": self.context},
                 executionType="AUTOMATED",
                 categories=["EnvironmentProvider", "LogAreaProvider", "External"],

--- a/src/log_area_provider/utilities/jsontas_provider.py
+++ b/src/log_area_provider/utilities/jsontas_provider.py
@@ -47,6 +47,7 @@ class JSONTasProvider:
         self.etos.config.set("logs", [])
         self.ruleset = ruleset
         self.id = self.ruleset.get("id")  # pylint:disable=invalid-name
+        self.context = self.etos.config.get("environment_provider_context")
         self.logger.info("Initialized log area provider %r", self.id)
 
     def checkout(self, available_log_areas):
@@ -85,7 +86,7 @@ class JSONTasProvider:
         checkin_log_areas = Checkin(self.jsontas, self.ruleset.get("checkin"))
         checkin_log_areas.checkin(log_area)
 
-    def wait_for_and_checkout_log_areas(self, minimum_amount=0, maximum_amount=100):
+    def _wait_for_and_checkout_log_areas(self, minimum_amount=0, maximum_amount=100):
         """Wait for and checkout log areas from an log area provider.
 
         :raises: LogAreaNotAvailable: If there are no available log areas after timeout.
@@ -145,3 +146,48 @@ class JSONTasProvider:
         if len(checked_out_log_areas) < minimum_amount:
             raise LogAreaNotAvailable(self.id)
         return checked_out_log_areas
+
+    def wait_for_and_checkout_log_areas(self, minimum_amount=0, maximum_amount=100):
+        """Wait for and checkout log areas from an log area provider.
+
+        See: `_wait_for_and_checkout_log_areas`
+
+        :raises: LogAreaNotAvailable: If there are no available log areas after timeout.
+
+        :param minimum_amount: Minimum amount of log areas to checkout.
+        :type minimum_amount: int
+        :param maximum_amount: Maximum amount of log areas to checkout.
+        :type maximum_amount: int
+        :return: List of checked out log areas.
+        :rtype: list
+        """
+        error = None
+        try:
+            triggered = self.etos.events.send_activity_triggered(
+                self.id,
+                {"CONTEXT": self.context},
+                executionType="AUTOMATED",
+                categories=["EnvironmentProvider", "LogAreaProvider"],
+                triggers=[
+                    {
+                        "type": "OTHER",
+                        "description": f"Checking out log areas",
+                    }
+                ],
+            )
+            self.etos.events.send_activity_started(triggered)
+            return self._wait_for_and_checkout_log_areas(
+                triggered, minimum_amount, maximum_amount
+            )
+        except Exception as exception:
+            error = exception
+            raise
+        finally:
+            if error is None:
+                outcome = {"conclusion": "SUCCESSFUL"}
+            else:
+                outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
+            self.etos.events.send_activity_finished(
+                triggered,
+                outcome,
+            )

--- a/src/log_area_provider/utilities/jsontas_provider.py
+++ b/src/log_area_provider/utilities/jsontas_provider.py
@@ -165,7 +165,7 @@ class JSONTasProvider:
         triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
-                self.id,
+                f"Checkout log areas from {self.id}",
                 {"CONTEXT": self.context},
                 executionType="AUTOMATED",
                 categories=["EnvironmentProvider", "LogAreaProvider"],

--- a/src/log_area_provider/utilities/jsontas_provider.py
+++ b/src/log_area_provider/utilities/jsontas_provider.py
@@ -177,7 +177,7 @@ class JSONTasProvider:
             )
             self.etos.events.send_activity_started(triggered)
             return self._wait_for_and_checkout_log_areas(
-                triggered, minimum_amount, maximum_amount
+                minimum_amount, maximum_amount
             )
         except Exception as exception:
             error = exception

--- a/src/log_area_provider/utilities/jsontas_provider.py
+++ b/src/log_area_provider/utilities/jsontas_provider.py
@@ -176,9 +176,7 @@ class JSONTasProvider:
                 ],
             )
             self.etos.events.send_activity_started(triggered)
-            return self._wait_for_and_checkout_log_areas(
-                minimum_amount, maximum_amount
-            )
+            return self._wait_for_and_checkout_log_areas(minimum_amount, maximum_amount)
         except Exception as exception:
             error = exception
             raise

--- a/src/log_area_provider/utilities/jsontas_provider.py
+++ b/src/log_area_provider/utilities/jsontas_provider.py
@@ -162,6 +162,7 @@ class JSONTasProvider:
         :rtype: list
         """
         error = None
+        triggered = None
         try:
             triggered = self.etos.events.send_activity_triggered(
                 self.id,
@@ -185,7 +186,5 @@ class JSONTasProvider:
                 outcome = {"conclusion": "SUCCESSFUL"}
             else:
                 outcome = {"conclusion": "UNSUCCESSFUL", "description": str(error)}
-            self.etos.events.send_activity_finished(
-                triggered,
-                outcome,
-            )
+            if triggered is not None:
+                self.etos.events.send_activity_finished(triggered, outcome)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#147

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added the sending of activity events in the environment provider.
We send one overarching activity that links to the ESR activity and then one activity for each test suite, which in turn sends an activity for each provider (with an extra prepare for the IUT provider).
The environments sent by the environment provider now links to the suite-activity instead which will break the ESR.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
There are multiple. Only sending one activity for the environment provider instead of one for each suite was denied since we want to be able to trace the completion of environments that the ESR tracks.
Wanted to add an activity for the prepare steps, but that will make it harder on the external providers.
The environment events could be kept as they were until we are ready to update the ESR or to do a smoother update, but I found no way of linking the environment events that could make the transition smooth.

### Benefits
<!-- What benefits will be realized by the change? -->
We will be able to trace more information from the environment provider as well as give better output to the ETOS client.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
There's a lot more events being sent.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
