### PR TITLE
User logs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,7 @@ import sys
 import inspect
 import shutil
 
-__location__ = os.path.join(
-    os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe()))
-)
+__location__ = os.path.join(os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe())))
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pylintrc
+++ b/pylintrc
@@ -1,3 +1,6 @@
+[main]
+extension-pkg-allow-list=falcon
+
 [messages control]
 disable=
     fixme

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,11 @@
 # Please have look at the docs for better alternatives
 # (`Dependency Management` section).
 # =============================================================================
-PyScaffold==3.2.3
-pyopenssl==19.1.0
-eventlet==0.26.1
-celery[redis]==4.4.7
-gunicorn==19.9.0
-gevent==20.9.0
-falcon==2.0.0
-jsontas==1.3.0
-packageurl-python==0.9.1
+eventlet~=0.33
+celery~=5.3
+gevent~=23.7
+gunicorn~=19.9
+falcon~=3.1
+jsontas~=1.3
+packageurl-python~=0.11
 etos_lib==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ gevent==20.9.0
 falcon==2.0.0
 jsontas==1.3.0
 packageurl-python==0.9.1
-etos_lib==2.1.0
+etos_lib==3.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
 	falcon==2.0.0
 	jsontas==1.3.0
 	packageurl-python==0.9.1
-        etos_lib==2.1.0
+    etos_lib==3.2.2
 
 python_requires = >=3.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,16 +26,14 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-	pyopenssl==19.1.0
-	eventlet==0.26.1
-	greenlet==1.1.3
-	celery==4.4.7
-	gevent==20.9.0
-	gunicorn==19.9.0
-	falcon==2.0.0
-	jsontas==1.3.0
-	packageurl-python==0.9.1
-    etos_lib==3.2.2
+	eventlet~=0.33
+	celery~=5.3
+	gevent~=23.7
+	gunicorn~=19.9
+	falcon~=3.1
+	jsontas~=1.3
+	packageurl-python~=0.11
+	etos_lib==3.2.2
 
 python_requires = >=3.8
 

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -347,15 +347,21 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         :return: The test suite and environment json for this checkout.
         :rtype: dict
         """
+        self.logger.info(
+            "Checkout environment for %r", test_suite_name, extra={"user_log": True}
+        )
         self.new_dataset(dataset)
 
         self.set_total_test_count_and_test_runners(test_runners)
         self.logger.info(
-            "Total test count : %r", self.etos.config.get("TOTAL_TEST_COUNT")
+            "Total test count: %d",
+            self.etos.config.get("TOTAL_TEST_COUNT"),
+            extra={"user_log": True},
         )
         self.logger.info(
             "Total testrunners: %r",
             self.etos.config.get("NUMBER_OF_TESTRUNNERS"),
+            extra={"user_log": True},
         )
         test_suite = TestSuite(
             test_suite_name,
@@ -369,6 +375,27 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
             + self.etos.config.get("WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
             + self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
             + 10
+        )
+        self.logger.info(
+            "Total timeout for checkout: %ds",
+            self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
+            + self.etos.config.get("WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
+            + self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
+            + 10,
+            extra={"user_log": True},
+        )
+        self.logger.info(
+            "Checking out IUTs from %r", self.iut_provider.id, extra={"user_log": True}
+        )
+        self.logger.info(
+            "Checking out execution spaces from %r",
+            self.execution_space_provider.id,
+            extra={"user_log": True},
+        )
+        self.logger.info(
+            "Checking out log areas from %r",
+            self.log_area_provider.id,
+            extra={"user_log": True},
         )
         finished = []
         while time.time() < timeout:
@@ -405,6 +432,11 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
                     sub_suite = test_suite.add(
                         test_runner, iut, suite, test_runners[test_runner]["priority"]
                     )
+                    self.logger.info(
+                        "Environment for %r checked out and is ready for use",
+                        sub_suite["name"],
+                        extra={"user_log": True},
+                    )
                     self.send_environment_events(sub_suite)
                 finished.append(test_runner)
 
@@ -428,6 +460,11 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         # This makes sure that we can cleanup if anything breaks.
         self.verify_json(test_suite_json)
 
+        self.logger.info(
+            "All environments for test suite %r have been checked out",
+            test_suite_name,
+            extra={"user_log": True},
+        )
         return test_suite_json
 
     def wait_for_main_suite(self, test_suite_id):
@@ -478,6 +515,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
                     {"CONTEXT": main_suite_id},
                     executionType="AUTOMATED",
                 )
+
                 self.etos.config.set("environment_provider_context", triggered)
                 self.etos.events.send_activity_started(triggered)
                 dataset = datasets.pop(0)

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -68,14 +68,15 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         :param test_db: Override the database with a test database.
         :type test_db: obj
         """
+        FORMAT_CONFIG.identifier = suite_id
+        self.logger.info("Initializing EnvironmentProvider task.")
+
+        self.etos = ETOS("ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider")
+
         self.suite_id = suite_id
         self.test_db = test_db
-        FORMAT_CONFIG.identifier = suite_id
         self.suite_runner_ids = suite_runner_ids
-        self.logger.info("Initializing EnvironmentProvider task.")
-        self.etos = ETOS(
-            "ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider"
-        )
+
         with self.lock:
             # Since celery workers can share memory between them we need to make the configuration
             # of ETOS library unique as it uses the memory sharing feature with the internal
@@ -106,16 +107,14 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         self.dataset.add("environment", os.environ)
         self.dataset.add("config", self.etos.config)
         self.dataset.add("identity", self.environment_provider_config.identity)
+        self.dataset.add("custom_data", self.environment_provider_config.custom_data)
+
         self.dataset.add("artifact_id", self.environment_provider_config.artifact_id)
         self.dataset.add("context", self.environment_provider_config.context)
-        self.dataset.add("custom_data", self.environment_provider_config.custom_data)
         self.dataset.add("uuid", str(uuid.uuid4()))
-        self.dataset.add(
-            "artifact_created", self.environment_provider_config.artifact_created
-        )
-        self.dataset.add(
-            "artifact_published", self.environment_provider_config.artifact_published
-        )
+
+        self.dataset.add("artifact_created", self.environment_provider_config.artifact_created)
+        self.dataset.add("artifact_published", self.environment_provider_config.artifact_published)
         self.dataset.add("tercc", self.environment_provider_config.tercc)
 
         self.dataset.add("dataset", dataset)
@@ -123,9 +122,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
 
         self.iut_provider = self.registry.iut_provider(self.suite_id)
         self.log_area_provider = self.registry.log_area_provider(self.suite_id)
-        self.execution_space_provider = self.registry.execution_space_provider(
-            self.suite_id
-        )
+        self.execution_space_provider = self.registry.execution_space_provider(self.suite_id)
 
     def configure(self, suite_id):
         """Configure environment provider.
@@ -144,9 +141,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         self.logger.info("Registry is configured.")
         self.etos.config.set("SUITE_ID", suite_id)
 
-        self.etos.config.set(
-            "EVENT_DATA_TIMEOUT", int(os.getenv("ETOS_EVENT_DATA_TIMEOUT", "10"))
-        )
+        self.etos.config.set("EVENT_DATA_TIMEOUT", int(os.getenv("ETOS_EVENT_DATA_TIMEOUT", "10")))
         self.etos.config.set(
             "WAIT_FOR_IUT_TIMEOUT", int(os.getenv("ETOS_WAIT_FOR_IUT_TIMEOUT", "10"))
         )
@@ -307,13 +302,10 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
             uri=f"{base_url}/sub_suite?id={identifier}",
             links={"CONTEXT": self.etos.config.get("environment_provider_context")},
         )
+
         self.database.write(event.meta.event_id, identifier)
-        self.database.writer.hset(
-            f"SubSuite:{identifier}", "EventID", event.meta.event_id
-        )
-        self.database.writer.hset(
-            f"SubSuite:{identifier}", "Suite", json.dumps(sub_suite)
-        )
+        self.database.writer.hset(f"SubSuite:{identifier}", "EventID", event.meta.event_id)
+        self.database.writer.hset(f"SubSuite:{identifier}", "Suite", json.dumps(sub_suite))
 
     def checkout_an_execution_space(self):
         """Check out a single execution space.
@@ -321,9 +313,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         :return: An execution space
         :rtype: obj:`execution_space_provider.execution_space`
         """
-        return self.execution_space_provider.wait_for_and_checkout_execution_spaces(
-            1, 1
-        )[0]
+        return self.execution_space_provider.wait_for_and_checkout_execution_spaces(1, 1)[0]
 
     def checkout_a_log_area(self):
         """Check out a single log area.
@@ -347,12 +337,11 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         :return: The test suite and environment json for this checkout.
         :rtype: dict
         """
-        self.logger.info(
-            "Checkout environment for %r", test_suite_name, extra={"user_log": True}
-        )
+        self.logger.info("Checkout environment for %r", test_suite_name, extra={"user_log": True})
         self.new_dataset(dataset)
 
         self.set_total_test_count_and_test_runners(test_runners)
+
         self.logger.info(
             "Total test count: %d",
             self.etos.config.get("TOTAL_TEST_COUNT"),
@@ -363,27 +352,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
             self.etos.config.get("NUMBER_OF_TESTRUNNERS"),
             extra={"user_log": True},
         )
-        test_suite = TestSuite(
-            test_suite_name,
-            main_suite_id,
-            self.environment_provider_config,
-            self.database,
-        )
 
-        timeout = time.time() + (
-            self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
-            + self.etos.config.get("WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
-            + self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
-            + 10
-        )
-        self.logger.info(
-            "Total timeout for checkout: %ds",
-            self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
-            + self.etos.config.get("WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
-            + self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
-            + 10,
-            extra={"user_log": True},
-        )
         self.logger.info(
             "Checking out IUTs from %r", self.iut_provider.id, extra={"user_log": True}
         )
@@ -397,8 +366,24 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
             self.log_area_provider.id,
             extra={"user_log": True},
         )
+
+        timeout = (
+            self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
+            + self.etos.config.get("WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
+            + self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
+            + 10
+        )
+        endtime = time.time() + timeout
+        self.logger.info("Total timeout for checkout: %ds", timeout, extra={"user_log": True})
+
+        test_suite = TestSuite(
+            test_suite_name,
+            main_suite_id,
+            self.environment_provider_config,
+            self.database,
+        )
         finished = []
-        while time.time() < timeout:
+        while time.time() < endtime:
             self.set_total_test_count_and_test_runners(test_runners)
             # Check out and assign IUTs to test runners.
             iuts = self.iut_provider.wait_for_and_checkout_iuts(
@@ -432,12 +417,13 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
                     sub_suite = test_suite.add(
                         test_runner, iut, suite, test_runners[test_runner]["priority"]
                     )
+                    self.send_environment_events(sub_suite)
+
                     self.logger.info(
                         "Environment for %r checked out and is ready for use",
                         sub_suite["name"],
                         extra={"user_log": True},
                     )
-                    self.send_environment_events(sub_suite)
                 finished.append(test_runner)
 
             # Remove finished sub suites.
@@ -500,14 +486,13 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
             ), "If multiple datasets are provided it must correspond with number of test suites"
         else:
             datasets = [datasets] * len(test_suites)
+
         for test_suite_name, test_runners in test_suites.items():
             triggered = None
             try:
                 main_suite = self.wait_for_main_suite(self.suite_runner_ids.pop(0))
                 if main_suite is None:
-                    raise TimeoutError(
-                        "Timed out while waiting for test suite started from ESR"
-                    )
+                    raise TimeoutError("Timed out while waiting for test suite started from ESR")
                 main_suite_id = main_suite["meta"]["id"]
 
                 triggered = self.etos.events.send_activity_triggered(
@@ -518,11 +503,10 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
 
                 self.etos.config.set("environment_provider_context", triggered)
                 self.etos.events.send_activity_started(triggered)
-                dataset = datasets.pop(0)
-                test_suite_json = self.checkout(
-                    test_suite_name, test_runners, dataset, main_suite_id
+
+                suites.append(
+                    self.checkout(test_suite_name, test_runners, datasets.pop(0), main_suite_id)
                 )
-                suites.append(test_suite_json)
             except Exception as exception:  # pylint:disable=broad-except
                 error = exception
                 raise
@@ -551,10 +535,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
             traceback.print_exc()
             return {"error": str(exception), "details": traceback.format_exc()}
         finally:
-            if (
-                self.etos.publisher is not None
-                and not self.etos.debug.disable_sending_events
-            ):
+            if self.etos.publisher is not None and not self.etos.debug.disable_sending_events:
                 self.etos.publisher.wait_for_unpublished_events()
                 self.etos.publisher.stop()
 

--- a/src/environment_provider/lib/celery.py
+++ b/src/environment_provider/lib/celery.py
@@ -30,9 +30,7 @@ if PASSWORD:
 else:
     CELERY_BROKER_URL = f"sentinel://{HOST}:{PORT}"
 
-APP = Celery(
-    "environment_provider", broker=CELERY_BROKER_URL, backend=CELERY_BROKER_URL
-)
+APP = Celery("environment_provider", broker=CELERY_BROKER_URL, backend=CELERY_BROKER_URL)
 if PASSWORD:
     APP.conf.broker_transport_options = {
         "master_name": "mymaster",

--- a/src/environment_provider/lib/celery.py
+++ b/src/environment_provider/lib/celery.py
@@ -45,4 +45,6 @@ if PASSWORD:
 else:
     APP.conf.broker_transport_options = {"master_name": "mymaster"}
     APP.conf.result_backend_transport_options = {"master_name": "mymaster"}
+APP.conf.broker_connection_retry = True
+APP.conf.broker_connection_retry_on_startup = True
 APP.conf.worker_hijack_root_logger = False

--- a/src/environment_provider/lib/config.py
+++ b/src/environment_provider/lib/config.py
@@ -98,9 +98,7 @@ class Config:  # pylint:disable=too-many-instance-attributes
         :rtype: tuple
         """
         try:
-            node_name, node = next(
-                self.__search_for_node_typename(response, node, key=key)
-            )
+            node_name, node = next(self.__search_for_node_typename(response, node, key=key))
             node = node.copy()
             try:
                 node.pop("reverse")
@@ -137,27 +135,19 @@ class Config:  # pylint:disable=too-many-instance-attributes
 
                 try:
                     response = request_tercc(self.etos, self.tercc_id)
-                    node = response["testExecutionRecipeCollectionCreated"]["edges"][0][
-                        "node"
-                    ]
+                    node = response["testExecutionRecipeCollectionCreated"]["edges"][0]["node"]
                     node = node.copy()
                     node.pop("links")
                     self.tercc = node
-                    _, self.artifact_created = self.__get_node(
-                        response, "ArtifactCreated", "links"
-                    )
+                    _, self.artifact_created = self.__get_node(response, "ArtifactCreated", "links")
 
                     response = request_activity_triggered(self.etos, self.tercc_id)
-                    self.activity_triggered = response["activityTriggered"]["edges"][0][
-                        "node"
-                    ]
+                    self.activity_triggered = response["activityTriggered"]["edges"][0]["node"]
 
                     response = request_artifact_published(self.etos, self.artifact_id)
                     # ArtifactPublished is not required and can be None.
                     if response:
-                        self.artifact_published = response["artifactPublished"][
-                            "edges"
-                        ][0]["node"]
+                        self.artifact_published = response["artifactPublished"]["edges"][0]["node"]
                 except:  # noqa, pylint:disable=bare-except
                     pass
                 time.sleep(1)
@@ -226,9 +216,7 @@ class Config:  # pylint:disable=too-many-instance-attributes
                 batch = self.tercc.get("data", {}).get("batches")
                 batch_uri = self.tercc.get("data", {}).get("batchesUri")
                 if batch is not None and batch_uri is not None:
-                    raise ValueError(
-                        "Only one of 'batches' or 'batchesUri' shall be set"
-                    )
+                    raise ValueError("Only one of 'batches' or 'batchesUri' shall be set")
                 if batch is not None:
                     self.__test_suite = batch
                 elif batch_uri is not None:

--- a/src/environment_provider/lib/registry.py
+++ b/src/environment_provider/lib/registry.py
@@ -101,9 +101,7 @@ class ProviderRegistry:
         :rtype: dict or None
         """
         self.logger.info("Getting log area provider %r", provider_id)
-        provider = self.database.reader.hget(
-            "EnvironmentProvider:LogAreaProviders", provider_id
-        )
+        provider = self.database.reader.hget("EnvironmentProvider:LogAreaProviders", provider_id)
         self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
@@ -120,9 +118,7 @@ class ProviderRegistry:
         :rtype: dict or None
         """
         self.logger.info("Getting iut provider %r", provider_id)
-        provider = self.database.reader.hget(
-            "EnvironmentProvider:IUTProviders", provider_id
-        )
+        provider = self.database.reader.hget("EnvironmentProvider:IUTProviders", provider_id)
         self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
@@ -155,9 +151,7 @@ class ProviderRegistry:
         """
         data = self.validate(ruleset, log_area_provider_schema(ruleset))
         self.logger.info("Registering %r", data)
-        self.database.writer.hdel(
-            "EnvironmentProvider:LogAreaProviders", data["log"]["id"]
-        )
+        self.database.writer.hdel("EnvironmentProvider:LogAreaProviders", data["log"]["id"])
         self.database.writer.hset(
             "EnvironmentProvider:LogAreaProviders", data["log"]["id"], json.dumps(data)
         )
@@ -208,9 +202,7 @@ class ProviderRegistry:
             provider = ExecutionSpaceProvider(
                 self.etos,
                 self.jsontas,
-                json.loads(provider_json, object_pairs_hook=OrderedDict).get(
-                    "execution_space"
-                ),
+                json.loads(provider_json, object_pairs_hook=OrderedDict).get("execution_space"),
             )
             self.etos.config.get("PROVIDERS").append(provider)
             return provider
@@ -224,9 +216,7 @@ class ProviderRegistry:
         :return: IUT provider object.
         :rtype: :obj:`environment_provider.iut.iut_provider.IutProvider`
         """
-        provider_str = self.database.reader.hget(
-            f"EnvironmentProvider:{suite_id}", "IUTProvider"
-        )
+        provider_str = self.database.reader.hget(f"EnvironmentProvider:{suite_id}", "IUTProvider")
         self.logger.info(provider_str)
         if provider_str:
             provider_json = json.loads(provider_str, object_pairs_hook=OrderedDict)
@@ -265,9 +255,7 @@ class ProviderRegistry:
         :return: Dataset JSON data.
         :rtype: dict
         """
-        dataset = self.database.reader.hget(
-            f"EnvironmentProvider:{suite_id}", "Dataset"
-        )
+        dataset = self.database.reader.hget(f"EnvironmentProvider:{suite_id}", "Dataset")
         if dataset:
             return json.loads(dataset)
         return None
@@ -302,13 +290,9 @@ class ProviderRegistry:
             "Execution space provider: %r",
             execution_space_provider.get("execution_space", {}).get("id"),
         )
-        self.logger.info(
-            "Log area provider: %r", log_area_provider.get("log", {}).get("id")
-        )
+        self.logger.info("Log area provider: %r", log_area_provider.get("log", {}).get("id"))
         self.logger.info("Expire: 3600")
-        self.database.writer.hset(
-            f"EnvironmentProvider:{suite_id}", "Dataset", json.dumps(dataset)
-        )
+        self.database.writer.hset(f"EnvironmentProvider:{suite_id}", "Dataset", json.dumps(dataset))
         self.database.writer.hset(
             f"EnvironmentProvider:{suite_id}",
             "IUTProvider",

--- a/src/environment_provider/lib/test_suite.py
+++ b/src/environment_provider/lib/test_suite.py
@@ -126,9 +126,7 @@ class TestSuite:
         }
     """
 
-    def __init__(
-        self, test_suite_name, suite_runner_id, environment_provider_config, database
-    ):
+    def __init__(self, test_suite_name, suite_runner_id, environment_provider_config, database):
         """Initialize test suite representation.
 
         :param test_suite_name: Name of the test suite.

--- a/src/environment_provider/splitter/split.py
+++ b/src/environment_provider/splitter/split.py
@@ -84,9 +84,7 @@ class Splitter:
                 number_of_iuts = 1
 
             number_of_tests = len(test_runner.get("unsplit_recipes"))
-            number_of_iuts = (
-                number_of_tests if number_of_tests < number_of_iuts else number_of_iuts
-            )
+            number_of_iuts = number_of_tests if number_of_tests < number_of_iuts else number_of_iuts
             test_runner["number_of_iuts"] = number_of_iuts
 
         while True:

--- a/src/environment_provider_api/backend/common.py
+++ b/src/environment_provider_api/backend/common.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Common functionality for all backend types."""
+from falcon.errors import MediaNotFoundError
 
 
 def get_suite_id(request):
@@ -24,9 +25,11 @@ def get_suite_id(request):
     :return: A Suite ID.
     :rtype: str
     """
-    if request.media is None:
+    try:
+        media = request.get_media()
+        return media.get("suite_id")
+    except MediaNotFoundError:
         return request.get_param("suite_id")
-    return request.media.get("suite_id")
 
 
 def get_suite_runner_ids(request):
@@ -37,10 +40,11 @@ def get_suite_runner_ids(request):
     :return: Suite runner IDs.
     :rtype: list
     """
-    if request.media is None:
+    try:
+        media = request.get_media()
+        param = media.get("suite_runner_ids")
+    except MediaNotFoundError:
         param = request.get_param("suite_runner_ids")
-    else:
-        param = request.media.get("suite_runner_ids")
     if param is None:
         return param
     return param.split(",")

--- a/src/environment_provider_api/backend/configure.py
+++ b/src/environment_provider_api/backend/configure.py
@@ -106,9 +106,7 @@ def configure(
     execution_space_provider = provider_registry.get_execution_space_provider_by_id(
         execution_space_provider_id
     )
-    log_area_provider = provider_registry.get_log_area_provider_by_id(
-        log_area_provider_id
-    )
+    log_area_provider = provider_registry.get_log_area_provider_by_id(log_area_provider_id)
     if not all(
         [
             iut_provider,

--- a/src/environment_provider_api/backend/configure.py
+++ b/src/environment_provider_api/backend/configure.py
@@ -25,7 +25,7 @@ def get_iut_provider_id(request):
     :return: An IUT provider ID.
     :rtype: str
     """
-    return request.media.get("iut_provider")
+    return request.get_media().get("iut_provider")
 
 
 def get_execution_space_provider_id(request):
@@ -36,7 +36,7 @@ def get_execution_space_provider_id(request):
     :return: An IUT provider ID.
     :rtype: str
     """
-    return request.media.get("execution_space_provider")
+    return request.get_media().get("execution_space_provider")
 
 
 def get_log_area_provider_id(request):
@@ -47,7 +47,7 @@ def get_log_area_provider_id(request):
     :return: An IUT provider ID.
     :rtype: str
     """
-    return request.media.get("log_area_provider")
+    return request.get_media().get("log_area_provider")
 
 
 def get_dataset(request):
@@ -58,7 +58,7 @@ def get_dataset(request):
     :return: An IUT provider ID.
     :rtype: dict
     """
-    dataset = request.media.get("dataset")
+    dataset = request.get_media().get("dataset")
     if dataset is not None:
         if not isinstance(dataset, (dict, list)):
             dataset = json.loads(dataset)

--- a/src/environment_provider_api/backend/environment.py
+++ b/src/environment_provider_api/backend/environment.py
@@ -197,7 +197,10 @@ def check_environment_status(celery_worker, environment_id):
     task_result = celery_worker.AsyncResult(environment_id)
     result = task_result.result
     status = task_result.status
-    if result and result.get("error") is not None:
+    if isinstance(result, Exception):
+        status = "FAILURE"
+        result = str(result)
+    elif result and result.get("error") is not None:
         status = "FAILURE"
     if result:
         task_result.get()

--- a/src/environment_provider_api/backend/environment.py
+++ b/src/environment_provider_api/backend/environment.py
@@ -97,9 +97,7 @@ def release_environment(etos, jsontas, provider_registry, sub_suite):
     """
     etos.config.set("SUITE_ID", sub_suite.get("suite_id"))
     iut = sub_suite.get("iut")
-    iut_ruleset = provider_registry.get_iut_provider_by_id(iut.get("provider_id")).get(
-        "iut"
-    )
+    iut_ruleset = provider_registry.get_iut_provider_by_id(iut.get("provider_id")).get("iut")
     executor = sub_suite.get("executor")
     executor_ruleset = provider_registry.get_execution_space_provider_by_id(
         executor.get("provider_id")
@@ -110,9 +108,7 @@ def release_environment(etos, jsontas, provider_registry, sub_suite):
     ).get("log")
 
     failure = None
-    success, exception = checkin_provider(
-        Iut(**iut), IutProvider(etos, jsontas, iut_ruleset)
-    )
+    success, exception = checkin_provider(Iut(**iut), IutProvider(etos, jsontas, iut_ruleset))
     if not success:
         failure = exception
 
@@ -155,16 +151,12 @@ def release_full_environment(
     for suite in task_result.result.get("suites", {}):
         for sub_suite in suite.get("sub_suites", []):
             try:
-                identifier = (
-                    f"SubSuite:{sub_suite['executor']['instructions']['identifier']}"
-                )
+                identifier = f"SubSuite:{sub_suite['executor']['instructions']['identifier']}"
             except KeyError:
                 identifier = None
             if identifier is not None:
                 event_id = provider_registry.database.reader.hget(identifier, "EventID")
-                event_suite = provider_registry.database.reader.hget(
-                    identifier, "Suite"
-                )
+                event_suite = provider_registry.database.reader.hget(identifier, "Suite")
                 # Has already been checked in.
                 if not event_suite:
                     continue

--- a/src/environment_provider_api/backend/register.py
+++ b/src/environment_provider_api/backend/register.py
@@ -25,7 +25,7 @@ def get_iut_provider(request):
     :return: An IUT provider from request.
     :rtype: dict or None
     """
-    return json_to_dict(request.media.get("iut_provider"))
+    return json_to_dict(request.get_media().get("iut_provider"))
 
 
 def get_log_area_provider(request):
@@ -36,7 +36,7 @@ def get_log_area_provider(request):
     :return: A log area provider from request.
     :rtype: dict or None
     """
-    return json_to_dict(request.media.get("log_area_provider"))
+    return json_to_dict(request.get_media().get("log_area_provider"))
 
 
 def get_execution_space_provider(request):
@@ -47,7 +47,7 @@ def get_execution_space_provider(request):
     :return: An execution space provider from request.
     :rtype: dict or None
     """
-    return json_to_dict(request.media.get("execution_space_provider"))
+    return json_to_dict(request.get_media().get("execution_space_provider"))
 
 
 def register(

--- a/src/environment_provider_api/backend/subsuite.py
+++ b/src/environment_provider_api/backend/subsuite.py
@@ -47,7 +47,5 @@ def get_id(request):
     """
     _id = request.get_param("id")
     if _id is None:
-        raise falcon.HTTPBadRequest(
-            "Missing parameter", "'id' is a required parameter."
-        )
+        raise falcon.HTTPBadRequest("Missing parameter", "'id' is a required parameter.")
     return _id

--- a/src/environment_provider_api/middleware/json_translator.py
+++ b/src/environment_provider_api/middleware/json_translator.py
@@ -29,6 +29,4 @@ class JSONTranslator:
 
         body = req.media
         if not body:
-            raise falcon.HTTPBadRequest(
-                "Empty request body", "A valid JSON document is required."
-            )
+            raise falcon.HTTPBadRequest("Empty request body", "A valid JSON document is required.")

--- a/src/environment_provider_api/webserver.py
+++ b/src/environment_provider_api/webserver.py
@@ -357,7 +357,7 @@ class SubSuite:  # pylint:disable=too-few-public-methods
         response.media = suite
 
 
-FALCON_APP = falcon.API(middleware=[RequireJSON(), JSONTranslator()])
+FALCON_APP = falcon.App(middleware=[RequireJSON(), JSONTranslator()])
 WEBSERVER = Webserver(Database, APP)
 CONFIGURE = Configure(Database)
 REGISTER = Register(Database)

--- a/src/environment_provider_api/webserver.py
+++ b/src/environment_provider_api/webserver.py
@@ -122,9 +122,7 @@ class Webserver:
             response.media = {
                 "error": "Failed to release environment",
                 "details": "".join(
-                    traceback.format_exception(
-                        failure, value=failure, tb=failure.__traceback__
-                    )
+                    traceback.format_exception(failure, value=failure, tb=failure.__traceback__)
                 ),
                 "status": "FAILURE",
             }
@@ -152,9 +150,7 @@ class Webserver:
         jsontas = JsonTas()
         registry = ProviderRegistry(etos, jsontas, self.database())
         task_result = self.celery_worker.AsyncResult(task_id)
-        success, message = release_full_environment(
-            etos, jsontas, registry, task_result, task_id
-        )
+        success, message = release_full_environment(etos, jsontas, registry, task_result, task_id)
         if not success:
             response.media = {
                 "error": "Failed to release environment",
@@ -242,9 +238,7 @@ class Configure:
         :param response: Falcon response object.
         :type response: :obj:`falcon.response`
         """
-        etos = ETOS(
-            "ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider"
-        )
+        etos = ETOS("ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider")
         jsontas = JsonTas()
         registry = ProviderRegistry(etos, jsontas, self.database())
         suite_id = get_suite_id(request)
@@ -273,17 +267,13 @@ class Configure:
         :param response: Falcon response object.
         :type response: :obj:`falcon.response`
         """
-        etos = ETOS(
-            "ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider"
-        )
+        etos = ETOS("ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider")
         jsontas = JsonTas()
         registry = ProviderRegistry(etos, jsontas, self.database())
 
         suite_id = get_suite_id(request)
         if suite_id is None:
-            raise falcon.HTTPBadRequest(
-                "Missing parameters", "'suite_id' is a required parameter."
-            )
+            raise falcon.HTTPBadRequest("Missing parameters", "'suite_id' is a required parameter.")
         FORMAT_CONFIG.identifier = suite_id
         response.status = falcon.HTTP_200
         response.media = get_configuration(registry, suite_id)
@@ -308,9 +298,7 @@ class Register:  # pylint:disable=too-few-public-methods
         :param response: Falcon response object.
         :type response: :obj:`falcon.response`
         """
-        etos = ETOS(
-            "ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider"
-        )
+        etos = ETOS("ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider")
         jsontas = JsonTas()
         registry = ProviderRegistry(etos, jsontas, self.database())
         registered = register(

--- a/src/execution_space_provider/execution_space_provider.py
+++ b/src/execution_space_provider/execution_space_provider.py
@@ -22,6 +22,8 @@ from .utilities.jsontas_provider import JSONTasProvider
 class ExecutionSpaceProvider:
     """Execution space provider."""
 
+    id = "Undefined"
+
     def __new__(cls, etos, jsontas, ruleset):
         """Check which type of provider and return an appropriate one."""
         if ruleset.get("type", "jsontas") == "external":

--- a/src/execution_space_provider/execution_space_provider.py
+++ b/src/execution_space_provider/execution_space_provider.py
@@ -45,9 +45,7 @@ class ExecutionSpaceProvider:
         """Check in all checked out execution spaces."""
 
     @abstractmethod
-    def wait_for_and_checkout_execution_spaces(
-        self, minimum_amount=0, maximum_amount=100
-    ):
+    def wait_for_and_checkout_execution_spaces(self, minimum_amount=0, maximum_amount=100):
         """Wait for and checkout execution spaces from an execution space provider.
 
         :raises: ExecutionSpaceNotAvailable: If there are no available execution spaces after

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -93,17 +93,11 @@ class ExternalProvider:
         end = int(end)
 
         if not isinstance(execution_space, list):
-            self.logger.debug(
-                "Check in execution space %r (timeout %ds)", execution_space, end
-            )
+            self.logger.debug("Check in execution space %r (timeout %ds)", execution_space, end)
             execution_space = [execution_space]
         else:
-            self.logger.debug(
-                "Check in execution spaces %r (timeout %ds)", execution_space, end
-            )
-        execution_spaces = [
-            execution_space.as_dict for execution_space in execution_space
-        ]
+            self.logger.debug("Check in execution spaces %r (timeout %ds)", execution_space, end)
+        execution_spaces = [execution_space.as_dict for execution_space in execution_space]
 
         host = self.ruleset.get("stop", {}).get("host")
         timeout = time.time() + end
@@ -122,8 +116,7 @@ class ExternalProvider:
                 response = response.json()
                 if response.get("error") is not None:
                     raise ExecutionSpaceCheckinFailed(
-                        f"Unable to check in {execution_spaces} "
-                        f"({response.get('error')})"
+                        f"Unable to check in {execution_spaces} " f"({response.get('error')})"
                     )
             except ConnectionError:
                 self.logger.error("Error connecting to %r", host)
@@ -170,12 +163,8 @@ class ExternalProvider:
             for response in response_iterator:
                 return response.get("id")
         except ConnectionError as http_error:
-            self.logger.error(
-                "Could not start external provider due to a connection error"
-            )
-            raise TimeoutError(
-                f"Unable to start external provider {self.id!r}"
-            ) from http_error
+            self.logger.error("Could not start external provider due to a connection error")
+            raise TimeoutError(f"Unable to start external provider {self.id!r}") from http_error
         raise TimeoutError(f"Unable to start external provider {self.id!r}")
 
     def wait(self, provider_id):
@@ -263,9 +252,7 @@ class ExternalProvider:
             for execution_space in response.get("execution_spaces", [])
         ]
 
-    def request_and_wait_for_execution_spaces(
-        self, minimum_amount=0, maximum_amount=100
-    ):
+    def request_and_wait_for_execution_spaces(self, minimum_amount=0, maximum_amount=100):
         """Wait for execution spaces from an external execution space provider.
 
         :raises: ExecutionSpaceNotAvailable: If there are no available execution spaces after
@@ -302,9 +289,7 @@ class ExternalProvider:
             raise
         return execution_spaces
 
-    def wait_for_and_checkout_execution_spaces(
-        self, minimum_amount=0, maximum_amount=100
-    ):
+    def wait_for_and_checkout_execution_spaces(self, minimum_amount=0, maximum_amount=100):
         """Wait for execution spaces from an external execution space provider.
 
         See: `request_and_wait_for_execution_spaces`
@@ -339,9 +324,7 @@ class ExternalProvider:
                 ],
             )
             self.etos.events.send_activity_started(triggered)
-            return self.request_and_wait_for_execution_spaces(
-                minimum_amount, maximum_amount
-            )
+            return self.request_and_wait_for_execution_spaces(minimum_amount, maximum_amount)
         except Exception as exception:
             error = exception
             raise

--- a/src/execution_space_provider/utilities/instructions.py
+++ b/src/execution_space_provider/utilities/instructions.py
@@ -51,6 +51,4 @@ class Instructions(DataStructure):  # pylint:disable=too-few-public-methods
         :param instructions: The instructions dictionary in which to add environments.
         :type instructions: dict
         """
-        instructions["environment"]["ETOS_FEATURE_CLM"] = os.getenv(
-            "ETOS_FEATURE_CLM", "true"
-        )
+        instructions["environment"]["ETOS_FEATURE_CLM"] = os.getenv("ETOS_FEATURE_CLM", "true")

--- a/src/execution_space_provider/utilities/jsontas_provider.py
+++ b/src/execution_space_provider/utilities/jsontas_provider.py
@@ -69,9 +69,7 @@ class JSONTasProvider:
         :return: Available execution spaces in the execution space provider.
         :rtype: list
         """
-        list_execution_spaces = List(
-            self.id, self.etos, self.jsontas, self.ruleset.get("list")
-        )
+        list_execution_spaces = List(self.id, self.etos, self.jsontas, self.ruleset.get("list"))
         return list_execution_spaces.list(amount)
 
     def checkin_all(self):
@@ -89,9 +87,7 @@ class JSONTasProvider:
         checkin_execution_spaces = Checkin(self.jsontas, self.ruleset.get("checkin"))
         checkin_execution_spaces.checkin(execution_space)
 
-    def _wait_for_and_checkout_execution_spaces(
-        self, minimum_amount=0, maximum_amount=100
-    ):
+    def _wait_for_and_checkout_execution_spaces(self, minimum_amount=0, maximum_amount=100):
         """Wait for and checkout execution spaces from an execution space provider.
 
         :raises: ExecutionSpaceNotAvailable: If there are no available execution spaces after
@@ -118,8 +114,7 @@ class JSONTasProvider:
                     self.logger.info(execution_space)
                 if len(available_execution_spaces) < minimum_amount:
                     self.logger.critical(
-                        "Not enough available execution spaces in "
-                        "execution space provider!"
+                        "Not enough available execution spaces in " "execution space provider!"
                     )
                     raise NotEnoughExecutionSpacesAvailable(self.id)
 
@@ -131,9 +126,7 @@ class JSONTasProvider:
                     raise ExecutionSpaceNotAvailable(self.id)
                 break
             except NoExecutionSpaceFound:
-                self.logger.critical(
-                    "Execution space does not exist in execution space provider!"
-                )
+                self.logger.critical("Execution space does not exist in execution space provider!")
                 checked_out_execution_spaces = []
                 break
             except ExecutionSpaceNotAvailable:
@@ -157,9 +150,7 @@ class JSONTasProvider:
             raise ExecutionSpaceNotAvailable(self.id)
         return checked_out_execution_spaces
 
-    def wait_for_and_checkout_execution_spaces(
-        self, minimum_amount=0, maximum_amount=100
-    ):
+    def wait_for_and_checkout_execution_spaces(self, minimum_amount=0, maximum_amount=100):
         """Wait for and checkout execution spaces from an execution space provider.
 
         See: `_wait_for_and_checkout_execution_spaces`
@@ -190,9 +181,7 @@ class JSONTasProvider:
                 ],
             )
             self.etos.events.send_activity_started(triggered)
-            return self._wait_for_and_checkout_execution_spaces(
-                minimum_amount, maximum_amount
-            )
+            return self._wait_for_and_checkout_execution_spaces(minimum_amount, maximum_amount)
         except Exception as exception:
             error = exception
             raise

--- a/src/iut_provider/iut.py
+++ b/src/iut_provider/iut.py
@@ -62,9 +62,7 @@ class Iut:
         :rtype: dict
         """
         iut_dictionary = deepcopy(self._iut_dictionary)
-        if iut_dictionary.get("identity") and not isinstance(
-            iut_dictionary.get("identity"), str
-        ):
+        if iut_dictionary.get("identity") and not isinstance(iut_dictionary.get("identity"), str):
             iut_dictionary["identity"] = iut_dictionary["identity"].to_string()
         return iut_dictionary
 

--- a/src/iut_provider/iut_provider.py
+++ b/src/iut_provider/iut_provider.py
@@ -22,6 +22,8 @@ from .utilities.jsontas_provider import JSONTasProvider
 class IutProvider:
     """Item under test (IUT) provider."""
 
+    id = "Undefined"
+
     def __new__(cls, etos, jsontas, ruleset):
         """Check which type of provider and return an appropriate one."""
         if ruleset.get("type", "jsontas") == "external":

--- a/src/iut_provider/utilities/external_provider.py
+++ b/src/iut_provider/utilities/external_provider.py
@@ -108,16 +108,12 @@ class ExternalProvider:
             else:
                 time.sleep(2)
             try:
-                response = requests.post(
-                    host, json=iuts, headers={"X-ETOS-ID": self.identifier}
-                )
+                response = requests.post(host, json=iuts, headers={"X-ETOS-ID": self.identifier})
                 if response.status_code == requests.codes["no_content"]:
                     return
                 response = response.json()
                 if response.get("error") is not None:
-                    raise IutCheckinFailed(
-                        f"Unable to check in {iuts} ({response.get('error')})"
-                    )
+                    raise IutCheckinFailed(f"Unable to check in {iuts} ({response.get('error')})")
             except ConnectionError:
                 self.logger.error("Error connecting to %r", host)
                 continue
@@ -163,12 +159,8 @@ class ExternalProvider:
             for response in response_iterator:
                 return response.get("id")
         except ConnectionError as http_error:
-            self.logger.error(
-                "Could not start external provider due to a connection error"
-            )
-            raise TimeoutError(
-                f"Unable to start external provider {self.id!r}"
-            ) from http_error
+            self.logger.error("Could not start external provider due to a connection error")
+            raise TimeoutError(f"Unable to start external provider {self.id!r}") from http_error
         raise TimeoutError(f"Unable to start external provider {self.id!r}")
 
     def wait(self, provider_id):
@@ -226,13 +218,9 @@ class ExternalProvider:
             self.logger.error("Could not parse response as JSON")
 
         if response.status_code == requests.codes["not_found"]:
-            raise IutNotAvailable(
-                f"External provider {self.id!r} did not respond properly"
-            )
+            raise IutNotAvailable(f"External provider {self.id!r} did not respond properly")
         if response.status_code == requests.codes["bad_request"]:
-            raise RuntimeError(
-                f"IUT provider for {self.id!r} is not properly configured"
-            )
+            raise RuntimeError(f"IUT provider for {self.id!r} is not properly configured")
 
         # This should work, no other errors found.
         # If this does not work, propagate JSONDecodeError up the stack.

--- a/src/iut_provider/utilities/jsontas_provider.py
+++ b/src/iut_provider/utilities/jsontas_provider.py
@@ -174,9 +174,7 @@ class JSONTasProvider:
                 for iut in prepared_iuts:
                     self.logger.info(iut)
                 if len(prepared_iuts) < minimum_amount:
-                    raise IutNotAvailable(
-                        f"Preparation of {self.identity.to_string()} failed"
-                    )
+                    raise IutNotAvailable(f"Preparation of {self.identity.to_string()} failed")
                 break
             except NoIutFound as not_found:
                 self.logger.critical(

--- a/src/iut_provider/utilities/list.py
+++ b/src/iut_provider/utilities/list.py
@@ -75,6 +75,5 @@ class List:  # pylint:disable=too-few-public-methods
         if not available_iuts:
             raise IutNotAvailable()
         return [
-            Iut(provider_id=self.id, identity=identity, **iut)
-            for iut in available_iuts[:amount]
+            Iut(provider_id=self.id, identity=identity, **iut) for iut in available_iuts[:amount]
         ]

--- a/src/log_area_provider/log_area_provider.py
+++ b/src/log_area_provider/log_area_provider.py
@@ -22,6 +22,8 @@ from .utilities.jsontas_provider import JSONTasProvider
 class LogAreaProvider:
     """Log area provider."""
 
+    id = "Undefined"
+
     def __new__(cls, etos, jsontas, ruleset):
         """Check which type of provider and return an appropriate one."""
         if ruleset.get("type", "jsontas") == "external":

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -162,12 +162,8 @@ class ExternalProvider:
             for response in response_iterator:
                 return response.get("id")
         except ConnectionError as http_error:
-            self.logger.error(
-                "Could not start external provider due to a connection error"
-            )
-            raise TimeoutError(
-                f"Unable to start external provider {self.id!r}"
-            ) from http_error
+            self.logger.error("Could not start external provider due to a connection error")
+            raise TimeoutError(f"Unable to start external provider {self.id!r}") from http_error
         raise TimeoutError(f"Unable to start external provider {self.id!r}")
 
     def wait(self, provider_id):
@@ -230,13 +226,9 @@ class ExternalProvider:
             self.logger.error("Could not parse response as JSON")
 
         if response.status_code == requests.codes["not_found"]:
-            raise LogAreaNotAvailable(
-                f"External provider {self.id!r} did not respond properly"
-            )
+            raise LogAreaNotAvailable(f"External provider {self.id!r} did not respond properly")
         if response.status_code == requests.codes["bad_request"]:
-            raise RuntimeError(
-                f"Log area provider for {self.id!r} is not properly configured"
-            )
+            raise RuntimeError(f"Log area provider for {self.id!r} is not properly configured")
 
         # This should work, no other errors found.
         # If this does not work, propagate JSONDecodeError up the stack.
@@ -251,8 +243,7 @@ class ExternalProvider:
         :rtype: list
         """
         return [
-            LogArea(provider_id=self.id, **log_area)
-            for log_area in response.get("log_areas", [])
+            LogArea(provider_id=self.id, **log_area) for log_area in response.get("log_areas", [])
         ]
 
     def request_and_wait_for_log_areas(self, minimum_amount=0, maximum_amount=100):

--- a/src/log_area_provider/utilities/jsontas_provider.py
+++ b/src/log_area_provider/utilities/jsontas_provider.py
@@ -111,9 +111,7 @@ class JSONTasProvider:
                 for log_area in available_log_areas:
                     self.logger.info(log_area)
                 if len(available_log_areas) < minimum_amount:
-                    self.logger.critical(
-                        "Not enough available log areas in log area provider!"
-                    )
+                    self.logger.critical("Not enough available log areas in log area provider!")
                     raise NotEnoughLogAreasAvailable(self.id)
 
                 checked_out_log_areas = self.checkout(available_log_areas)
@@ -131,9 +129,7 @@ class JSONTasProvider:
                 self.logger.warning("Log area not available yet.")
                 continue
             except LogAreaCheckoutFailed as checkout_failed:
-                self.logger.critical(
-                    "Checkout of log area failed with reason %r!", checkout_failed
-                )
+                self.logger.critical("Checkout of log area failed with reason %r!", checkout_failed)
                 self.checkin_all()
                 checked_out_log_areas = []
                 break

--- a/src/log_area_provider/utilities/list.py
+++ b/src/log_area_provider/utilities/list.py
@@ -63,20 +63,15 @@ class List:  # pylint:disable=too-few-public-methods
         log_areas = self.jsontas.run(self.list_ruleset)
         possible_log_areas = log_areas.get("possible")
 
-        self.logger.debug(
-            "Number of possible log areas available: %r", len(possible_log_areas)
-        )
+        self.logger.debug("Number of possible log areas available: %r", len(possible_log_areas))
         if not possible_log_areas:
             raise NoLogAreaFound()
 
         available_log_areas = log_areas.get("available")
 
-        self.logger.debug(
-            "Number of actual log areas available: %r", len(available_log_areas)
-        )
+        self.logger.debug("Number of actual log areas available: %r", len(available_log_areas))
         if not available_log_areas:
             raise LogAreaNotAvailable()
         return [
-            LogArea(provider_id=self.id, **log_area)
-            for log_area in available_log_areas[:amount]
+            LogArea(provider_id=self.id, **log_area) for log_area in available_log_areas[:amount]
         ]

--- a/tests/backend/test_common.py
+++ b/tests/backend/test_common.py
@@ -58,9 +58,7 @@ class TestCommonFunctionality(unittest.TestCase):
         request.force_media_none = True
         test_suite_id = "b58415d4-2f39-4ab0-8763-7277e18f9606"
         request.fake_params["suite_id"] = test_suite_id
-        self.logger.info(
-            "STEP: Get suite id from request via the configure backend without media."
-        )
+        self.logger.info("STEP: Get suite id from request via the configure backend without media.")
         response_suite_id = get_suite_id(request)
 
         self.logger.info("STEP: Verify that the backend returns the suite id.")

--- a/tests/backend/test_configure.py
+++ b/tests/backend/test_configure.py
@@ -56,14 +56,10 @@ class TestConfigureBackend(unittest.TestCase):
         request = FakeRequest()
         test_provider_id = "test_iut_provider"
         request.fake_params["iut_provider"] = test_provider_id
-        self.logger.info(
-            "STEP: Get IUT provider id from request via the configure backend."
-        )
+        self.logger.info("STEP: Get IUT provider id from request via the configure backend.")
         response_provider_id = get_iut_provider_id(request)
 
-        self.logger.info(
-            "STEP: Verify that the backend returns the correct iut provider id."
-        )
+        self.logger.info("STEP: Verify that the backend returns the correct iut provider id.")
         self.assertEqual(test_provider_id, response_provider_id)
 
     def test_iut_provider_id_none(self):
@@ -76,9 +72,7 @@ class TestConfigureBackend(unittest.TestCase):
             1. Get IUT provider from request via the configure backend.
             2. Verify that the backend returns None.
         """
-        self.logger.info(
-            "STEP: Get IUT provider id from request via the configure backend."
-        )
+        self.logger.info("STEP: Get IUT provider id from request via the configure backend.")
         response = get_iut_provider_id(FakeRequest())
 
         self.logger.info("STEP: Verify that the backend returns None.")
@@ -139,14 +133,10 @@ class TestConfigureBackend(unittest.TestCase):
         request = FakeRequest()
         test_provider_id = "test_log_area_provider_id"
         request.fake_params["log_area_provider"] = test_provider_id
-        self.logger.info(
-            "STEP: Get log area provider id from request via the configure backend."
-        )
+        self.logger.info("STEP: Get log area provider id from request via the configure backend.")
         response_provider_id = get_log_area_provider_id(request)
 
-        self.logger.info(
-            "STEP: Verify that the backend returns the correct log area provider id."
-        )
+        self.logger.info("STEP: Verify that the backend returns the correct log area provider id.")
         self.assertEqual(test_provider_id, response_provider_id)
 
     def test_log_area_provider_id_none(self):
@@ -159,9 +149,7 @@ class TestConfigureBackend(unittest.TestCase):
             1. Get log area provider from request via the configure backend.
             2. Verify that the backend returns None.
         """
-        self.logger.info(
-            "STEP: Get log area provider id from request via the configure backend."
-        )
+        self.logger.info("STEP: Get log area provider id from request via the configure backend.")
         response = get_log_area_provider_id(FakeRequest())
 
         self.logger.info("STEP: Verify that the backend returns None.")
@@ -264,26 +252,18 @@ class TestConfigureBackend(unittest.TestCase):
             test_suite_id,
         )
 
-        self.logger.info(
-            "STEP: Verify that the configuration was stored in the database."
-        )
+        self.logger.info("STEP: Verify that the configuration was stored in the database.")
         self.assertTrue(success)
         stored_iut_provider = json.loads(
             database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "IUTProvider")
         )
         self.assertDictEqual(stored_iut_provider, test_iut_provider)
         stored_execution_space_provider = json.loads(
-            database.reader.hget(
-                f"EnvironmentProvider:{test_suite_id}", "ExecutionSpaceProvider"
-            )
+            database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "ExecutionSpaceProvider")
         )
-        self.assertDictEqual(
-            stored_execution_space_provider, test_execution_space_provider
-        )
+        self.assertDictEqual(stored_execution_space_provider, test_execution_space_provider)
         stored_log_area_provider = json.loads(
-            database.reader.hget(
-                f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider"
-            )
+            database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider")
         )
         self.assertDictEqual(stored_log_area_provider, test_log_area_provider)
         stored_dataset = json.loads(
@@ -309,9 +289,7 @@ class TestConfigureBackend(unittest.TestCase):
         registry = ProviderRegistry(ETOS("", "", ""), JsonTas(), database)
         success, _ = configure(registry, None, None, None, None, None)
 
-        self.logger.info(
-            "STEP: Verify that False was returned and no configuration was made."
-        )
+        self.logger.info("STEP: Verify that False was returned and no configuration was made.")
         self.assertFalse(success)
         self.assertDictEqual(database.db_dict, {})
 
@@ -377,26 +355,18 @@ class TestConfigureBackend(unittest.TestCase):
             test_suite_id,
         )
 
-        self.logger.info(
-            "STEP: Verify that the configuration was stored in the database."
-        )
+        self.logger.info("STEP: Verify that the configuration was stored in the database.")
         self.assertTrue(success)
         stored_iut_provider = json.loads(
             database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "IUTProvider")
         )
         self.assertDictEqual(stored_iut_provider, test_iut_provider)
         stored_execution_space_provider = json.loads(
-            database.reader.hget(
-                f"EnvironmentProvider:{test_suite_id}", "ExecutionSpaceProvider"
-            )
+            database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "ExecutionSpaceProvider")
         )
-        self.assertDictEqual(
-            stored_execution_space_provider, test_execution_space_provider
-        )
+        self.assertDictEqual(stored_execution_space_provider, test_execution_space_provider)
         stored_log_area_provider = json.loads(
-            database.reader.hget(
-                f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider"
-            )
+            database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider")
         )
         self.assertDictEqual(stored_log_area_provider, test_log_area_provider)
         stored_dataset = json.loads(
@@ -461,18 +431,14 @@ class TestConfigureBackend(unittest.TestCase):
             json.dumps(test_log_area_provider),
         )
 
-        self.logger.info(
-            "STEP: Verify that it is possible to get the stored configuration."
-        )
+        self.logger.info("STEP: Verify that it is possible to get the stored configuration.")
         registry = ProviderRegistry(ETOS("", "", ""), JsonTas(), database)
         stored_configuration = get_configuration(registry, test_suite_id)
         self.assertDictEqual(
             stored_configuration,
             {
                 "iut_provider": test_iut_provider["iut"],
-                "execution_space_provider": test_execution_space_provider[
-                    "execution_space"
-                ],
+                "execution_space_provider": test_execution_space_provider["execution_space"],
                 "log_area_provider": test_log_area_provider["log"],
                 "dataset": test_dataset,
             },
@@ -497,9 +463,7 @@ class TestConfigureBackend(unittest.TestCase):
             f"EnvironmentProvider:{test_suite_id}", "Dataset", json.dumps(test_dataset)
         )
 
-        self.logger.info(
-            "STEP: Verify that it is possible to get the partial configuration."
-        )
+        self.logger.info("STEP: Verify that it is possible to get the partial configuration.")
         registry = ProviderRegistry(ETOS("", "", ""), JsonTas(), database)
         stored_configuration = get_configuration(registry, test_suite_id)
         self.assertDictEqual(

--- a/tests/backend/test_environment.py
+++ b/tests/backend/test_environment.py
@@ -66,9 +66,7 @@ class TestEnvironmentBackend(unittest.TestCase):
             test_value = f"testing_{parameter}"
             request = FakeRequest()
             request.fake_params[parameter] = test_value
-            self.logger.info(
-                "STEP: Call the function to get the parameter %r", parameter
-            )
+            self.logger.info("STEP: Call the function to get the parameter %r", parameter)
             response_value = func(request)
             self.logger.info("STEP: Verify that the parameter is correct.")
             self.assertEqual(response_value, test_value)
@@ -167,9 +165,7 @@ class TestEnvironmentBackend(unittest.TestCase):
             test_release_id,
         )
 
-        self.logger.info(
-            "STEP: Verify that it was possible to release that environment."
-        )
+        self.logger.info("STEP: Verify that it was possible to release that environment.")
         self.assertTrue(success)
         self.assertIsNone(worker.AsyncResult(test_release_id))
 
@@ -256,9 +252,7 @@ class TestEnvironmentBackend(unittest.TestCase):
             },
         )
 
-        self.logger.info(
-            "STEP: Release an environment where one provider will fail to check in."
-        )
+        self.logger.info("STEP: Release an environment where one provider will fail to check in.")
         success, _ = release_full_environment(
             etos,
             jsontas,
@@ -339,8 +333,6 @@ class TestEnvironmentBackend(unittest.TestCase):
         self.logger.info("STEP: Request an environment from the environment provider.")
         response = request_environment(suite_id, suite_runner_id)
 
-        self.logger.info(
-            "STEP: Verify that the environment provider starts the celery task."
-        )
+        self.logger.info("STEP: Verify that the environment provider starts the celery task.")
         self.assertEqual(response, task_id)
         get_environment_mock.delay.assert_called_once_with(suite_id, suite_runner_id)

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -52,14 +52,10 @@ class TestRegisterBackend(unittest.TestCase):
         request = FakeRequest()
         test_iut_provider = {"iut": {"id": "providertest"}}
         request.fake_params["iut_provider"] = test_iut_provider
-        self.logger.info(
-            "STEP: Get IUT provider from request via the register backend."
-        )
+        self.logger.info("STEP: Get IUT provider from request via the register backend.")
         response_iut_provider = get_iut_provider(request)
 
-        self.logger.info(
-            "STEP: Verify that the backend returns the correct iut provider."
-        )
+        self.logger.info("STEP: Verify that the backend returns the correct iut provider.")
         self.assertDictEqual(test_iut_provider, response_iut_provider)
 
     def test_iut_provider_none(self):
@@ -73,9 +69,7 @@ class TestRegisterBackend(unittest.TestCase):
             2. Verify that the backend returns None.
         """
         request = FakeRequest()
-        self.logger.info(
-            "STEP: Get IUT provider from request via the register backend."
-        )
+        self.logger.info("STEP: Get IUT provider from request via the register backend.")
         response_iut_provider = get_iut_provider(request)
 
         self.logger.info("STEP: Verify that the backend returns None.")
@@ -103,9 +97,7 @@ class TestRegisterBackend(unittest.TestCase):
         self.logger.info(
             "STEP: Verify that the backend returns the correct execution space provider."
         )
-        self.assertDictEqual(
-            test_execution_space_provider, response_execution_space_provider
-        )
+        self.assertDictEqual(test_execution_space_provider, response_execution_space_provider)
 
     def test_execution_space_provider_none(self):
         """Test that the register backend returns None if execution space provider is not set.
@@ -140,14 +132,10 @@ class TestRegisterBackend(unittest.TestCase):
         request = FakeRequest()
         test_log_area_provider = {"log": {"id": "providertest"}}
         request.fake_params["log_area_provider"] = test_log_area_provider
-        self.logger.info(
-            "STEP: Get log area provider from request via the register backend."
-        )
+        self.logger.info("STEP: Get log area provider from request via the register backend.")
         response_log_area_provider = get_log_area_provider(request)
 
-        self.logger.info(
-            "STEP: Verify that the backend returns the correct log area provider."
-        )
+        self.logger.info("STEP: Verify that the backend returns the correct log area provider.")
         self.assertDictEqual(test_log_area_provider, response_log_area_provider)
 
     def test_log_area_provider_none(self):
@@ -161,9 +149,7 @@ class TestRegisterBackend(unittest.TestCase):
             2. Verify that the backend returns None.
         """
         request = FakeRequest()
-        self.logger.info(
-            "STEP: Get log area provider from request via the register backend."
-        )
+        self.logger.info("STEP: Get log area provider from request via the register backend.")
         response_log_area_provider = get_log_area_provider(request)
 
         self.logger.info("STEP: Verify that the backend returns None.")
@@ -179,9 +165,7 @@ class TestRegisterBackend(unittest.TestCase):
             1. Verify that the json_to_dict converts JSON strings to dictionary.
         """
         json_string = '{"data": "testing"}'
-        self.logger.info(
-            "STEP: Verify that the json_to_dict converts JSON strings to dictionary."
-        )
+        self.logger.info("STEP: Verify that the json_to_dict converts JSON strings to dictionary.")
         json_dict = json_to_dict(json_string)
         self.assertDictEqual(json_dict, json.loads(json_string))
 
@@ -194,9 +178,7 @@ class TestRegisterBackend(unittest.TestCase):
         Test steps:
             1. Verify that the json_to_dict returns None when json_str is None.
         """
-        self.logger.info(
-            "Verify that the json_to_dict returns None when json_str is None."
-        )
+        self.logger.info("Verify that the json_to_dict returns None when json_str is None.")
         self.assertIsNone(json_to_dict(None))
 
     def test_json_to_dict_already_dict(self):
@@ -238,13 +220,9 @@ class TestRegisterBackend(unittest.TestCase):
         self.logger.info("STEP: Register an IUT provider with the register backend.")
         response = register(provider_registry, iut_provider=provider)
 
-        self.logger.info(
-            "STEP: Verify that the IUT provider was stored in the database."
-        )
+        self.logger.info("STEP: Verify that the IUT provider was stored in the database.")
         stored_provider = json.loads(
-            fake_database.reader.hget(
-                "EnvironmentProvider:IUTProviders", "iut_provider_test"
-            )
+            fake_database.reader.hget("EnvironmentProvider:IUTProviders", "iut_provider_test")
         )
         self.assertDictEqual(stored_provider, provider)
         self.assertTrue(response)
@@ -269,14 +247,10 @@ class TestRegisterBackend(unittest.TestCase):
             }
         }
         provider_registry = ProviderRegistry(etos, jsontas, fake_database)
-        self.logger.info(
-            "STEP: Register a log area provider with the register backend."
-        )
+        self.logger.info("STEP: Register a log area provider with the register backend.")
         response = register(provider_registry, log_area_provider=provider)
 
-        self.logger.info(
-            "STEP: Verify that the log area provider was stored in the database."
-        )
+        self.logger.info("STEP: Verify that the log area provider was stored in the database.")
         stored_provider = json.loads(
             fake_database.reader.hget(
                 "EnvironmentProvider:LogAreaProviders", "log_area_provider_test"
@@ -305,9 +279,7 @@ class TestRegisterBackend(unittest.TestCase):
             }
         }
         provider_registry = ProviderRegistry(etos, jsontas, fake_database)
-        self.logger.info(
-            "STEP: Register an execution space provider with the register backend."
-        )
+        self.logger.info("STEP: Register an execution space provider with the register backend.")
         response = register(provider_registry, execution_space_provider=provider)
 
         self.logger.info(
@@ -354,9 +326,7 @@ class TestRegisterBackend(unittest.TestCase):
             }
         }
         provider_registry = ProviderRegistry(etos, jsontas, fake_database)
-        self.logger.info(
-            "STEP: Register one of each provider with the register backend."
-        )
+        self.logger.info("STEP: Register one of each provider with the register backend.")
         response = register(
             provider_registry,
             iut_provider=test_iut_provider,
@@ -382,9 +352,7 @@ class TestRegisterBackend(unittest.TestCase):
         )
         self.assertDictEqual(stored_log_area_provider, test_log_area_provider)
         stored_iut_provider = json.loads(
-            fake_database.reader.hget(
-                "EnvironmentProvider:IUTProviders", "iut_provider_test"
-            )
+            fake_database.reader.hget("EnvironmentProvider:IUTProviders", "iut_provider_test")
         )
         self.assertDictEqual(stored_iut_provider, test_iut_provider)
         self.assertTrue(response)

--- a/tests/backend/test_sub_suite.py
+++ b/tests/backend/test_sub_suite.py
@@ -45,9 +45,7 @@ class TestSubSuiteBackend(unittest.TestCase):
         request.fake_params["id"] = test_id
         self.logger.info("STEP: Get Suite ID from request via the suite id function.")
         response_id = get_id(request)
-        self.logger.info(
-            "STEP: Verify that the suite id function return the correct ID."
-        )
+        self.logger.info("STEP: Verify that the suite id function return the correct ID.")
         self.assertEqual(test_id, response_id)
 
     def test_suite_id_missing(self):
@@ -63,9 +61,7 @@ class TestSubSuiteBackend(unittest.TestCase):
         request = FakeRequest()
         request.fake_params["id"] = None
         self.logger.info("STEP: Get Suite ID from request via the suite id function.")
-        self.logger.info(
-            "STEP: Verify that the suite id function raises falcon.HTTPBadRequest."
-        )
+        self.logger.info("STEP: Verify that the suite id function raises falcon.HTTPBadRequest.")
         with self.assertRaises(falcon.HTTPBadRequest):
             get_id(request)
 
@@ -86,9 +82,7 @@ class TestSubSuiteBackend(unittest.TestCase):
         database.write("mysuite", json.dumps(test_suite))
         self.logger.info("STEP: Get the sub suite from the subsuite backend.")
         response_suite = get_sub_suite(database, "mysuite")
-        self.logger.info(
-            "STEP: Verify that the sub suite is the one stored in the database."
-        )
+        self.logger.info("STEP: Verify that the sub suite is the one stored in the database.")
         self.assertDictEqual(test_suite, response_suite)
 
     def test_sub_suite_does_not_exist(self):

--- a/tests/external_execution_space/test_external_execution_space.py
+++ b/tests/external_execution_space/test_external_execution_space.py
@@ -76,9 +76,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a start request.")
             start_id = provider.start(1, 2)
-            self.logger.info(
-                "STEP: Verify that the ID from the start request is returned."
-            )
+            self.logger.info("STEP: Verify that the ID from the start request is returned.")
             self.assertEqual(start_id, expected_start_id)
 
     def test_provider_start_http_exception(self):
@@ -107,9 +105,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
         )
         expected_start_id = "123"
 
-        with FakeServer(
-            ["bad_request", "ok"], [{}, {"id": expected_start_id}]
-        ) as server:
+        with FakeServer(["bad_request", "ok"], [{}, {"id": expected_start_id}]) as server:
             ruleset = {
                 "id": "test_provider_start_http_exception",
                 "start": {"host": server.host},
@@ -118,9 +114,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a start request that fails.")
             start_id = provider.start(1, 2)
-            self.logger.info(
-                "STEP: Verify that the start method tries again on HTTP errors."
-            )
+            self.logger.info("STEP: Verify that the start method tries again on HTTP errors.")
             self.assertGreaterEqual(server.nbr_of_requests, 2)
             self.assertEqual(start_id, expected_start_id)
 
@@ -160,9 +154,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
             self.logger.info("STEP: Send a start request which will never finish.")
 
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the start method raises TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the start method raises TimeoutError.")
                 provider.start(1, 2)
 
     def test_provider_stop(self):
@@ -234,9 +226,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
                 "execution_spaces": execution_spaces,
             }
         )
-        dict_execution_spaces = [
-            execution_space.as_dict for execution_space in execution_spaces
-        ]
+        dict_execution_spaces = [execution_space.as_dict for execution_space in execution_spaces]
 
         with FakeServer("no_content", {}) as server:
             ruleset = {"id": "test_provider_stop_many", "stop": {"host": server.host}}
@@ -322,9 +312,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a stop request that fails.")
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the checkin method raises a TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the checkin method raises a TimeoutError.")
                 provider.checkin(execution_space)
 
     def test_provider_status(self):
@@ -357,13 +345,9 @@ class TestExternalExecutionSpace(unittest.TestCase):
             ruleset = {"id": "test_provider_status", "status": {"host": server.host}}
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a status request for a started execution space provider."
-            )
+            self.logger.info("STEP: Send a status request for a started execution space provider.")
             response = provider.wait("1")
-            self.logger.info(
-                "STEP: Verify that the wait method return response on DONE."
-            )
+            self.logger.info("STEP: Verify that the wait method return response on DONE.")
             self.assertEqual(response.get("test_id"), test_id)
 
     def test_provider_status_pending(self):
@@ -399,9 +383,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
             }
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a status request for a started execution space provider."
-            )
+            self.logger.info("STEP: Send a status request for a started execution space provider.")
             provider.wait("1")
             self.logger.info("STEP: Verify that the wait method waits on PENDING.")
             self.assertEqual(server.nbr_of_requests, len(responses))
@@ -432,18 +414,14 @@ class TestExternalExecutionSpace(unittest.TestCase):
             }
         )
         description = "something failed!"
-        with FakeServer(
-            "ok", {"status": "FAILED", "description": description}
-        ) as server:
+        with FakeServer("ok", {"status": "FAILED", "description": description}) as server:
             ruleset = {
                 "id": "test_provider_status_failed",
                 "status": {"host": server.host},
             }
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a status request for a started execution space provider."
-            )
+            self.logger.info("STEP: Send a status request for a started execution space provider.")
             with self.assertRaises(ExecutionSpaceCheckoutFailed):
                 self.logger.info(
                     "STEP: Verify that the wait method raises ExecutionSpaceCheckoutFailed."
@@ -532,9 +510,7 @@ class TestExternalExecutionSpace(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a status request that times out.")
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the wait method raises TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the wait method raises TimeoutError.")
                 provider.wait("1")
 
     def test_request_and_wait(self):

--- a/tests/external_iut/test_external_iut.py
+++ b/tests/external_iut/test_external_iut.py
@@ -74,9 +74,7 @@ class TestExternalIUT(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a start request.")
             start_id = provider.start(1, 2)
-            self.logger.info(
-                "STEP: Verify that the ID from the start request is returned."
-            )
+            self.logger.info("STEP: Verify that the ID from the start request is returned.")
             self.assertEqual(start_id, expected_start_id)
 
     def test_provider_start_http_exception(self):
@@ -105,9 +103,7 @@ class TestExternalIUT(unittest.TestCase):
         )
         expected_start_id = "123"
 
-        with FakeServer(
-            ["bad_request", "ok"], [{}, {"id": expected_start_id}]
-        ) as server:
+        with FakeServer(["bad_request", "ok"], [{}, {"id": expected_start_id}]) as server:
             ruleset = {
                 "id": "test_provider_start_http_exception",
                 "start": {"host": server.host},
@@ -116,9 +112,7 @@ class TestExternalIUT(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a start request that fails.")
             start_id = provider.start(1, 2)
-            self.logger.info(
-                "STEP: Verify that the start method tries again on HTTP errors."
-            )
+            self.logger.info("STEP: Verify that the start method tries again on HTTP errors.")
             self.assertGreaterEqual(server.nbr_of_requests, 2)
             self.assertEqual(start_id, expected_start_id)
 
@@ -158,9 +152,7 @@ class TestExternalIUT(unittest.TestCase):
             self.logger.info("STEP: Send a start request which will never finish.")
 
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the start method raises TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the start method raises TimeoutError.")
                 provider.start(1, 2)
 
     def test_provider_stop(self):
@@ -312,9 +304,7 @@ class TestExternalIUT(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a stop request that fails.")
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the checkin method raises a TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the checkin method raises a TimeoutError.")
                 provider.checkin(iut)
 
     def test_provider_status(self):
@@ -349,9 +339,7 @@ class TestExternalIUT(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a status request for a started IUT provider.")
             response = provider.wait("1")
-            self.logger.info(
-                "STEP: Verify that the wait method return response on DONE."
-            )
+            self.logger.info("STEP: Verify that the wait method return response on DONE.")
             self.assertEqual(response.get("test_id"), test_id)
 
     def test_provider_status_pending(self):
@@ -418,9 +406,7 @@ class TestExternalIUT(unittest.TestCase):
             }
         )
         description = "something failed!"
-        with FakeServer(
-            "ok", {"status": "FAILED", "description": description}
-        ) as server:
+        with FakeServer("ok", {"status": "FAILED", "description": description}) as server:
             ruleset = {
                 "id": "test_provider_status_failed",
                 "status": {"host": server.host},
@@ -429,9 +415,7 @@ class TestExternalIUT(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a status request for a started IUT provider.")
             with self.assertRaises(IutCheckoutFailed):
-                self.logger.info(
-                    "STEP: Verify that the wait method raises IutCheckoutFailed."
-                )
+                self.logger.info("STEP: Verify that the wait method raises IutCheckoutFailed.")
                 provider.wait("1")
 
     def test_provider_status_http_exceptions(self):
@@ -473,9 +457,7 @@ class TestExternalIUT(unittest.TestCase):
                 }
                 self.logger.info("STEP: Initialize an external provider.")
                 provider = ExternalProvider(etos, jsontas, ruleset)
-                self.logger.info(
-                    "STEP: Send a status request for a started IUT provider."
-                )
+                self.logger.info("STEP: Send a status request for a started IUT provider.")
                 with self.assertRaises(exception):
                     self.logger.info(
                         "STEP: Verify that the wait method raises the correct exception."
@@ -516,9 +498,7 @@ class TestExternalIUT(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a status request that times out.")
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the wait method raises TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the wait method raises TimeoutError.")
                 provider.wait("1")
 
     def test_request_and_wait(self):
@@ -565,15 +545,9 @@ class TestExternalIUT(unittest.TestCase):
             }
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a checkout request via the external IUT provider."
-            )
+            self.logger.info("STEP: Send a checkout request via the external IUT provider.")
             iuts = provider.request_and_wait_for_iuts()
-            self.logger.info(
-                "STEP: Verify that the provider returns a list of checked out IUTs."
-            )
+            self.logger.info("STEP: Verify that the provider returns a list of checked out IUTs.")
             dict_iuts = [iut.as_dict for iut in iuts]
-            test_iuts = [
-                Iut(provider_id=provider_id, test_id=test_id, identity=identity).as_dict
-            ]
+            test_iuts = [Iut(provider_id=provider_id, test_id=test_id, identity=identity).as_dict]
             self.assertEqual(dict_iuts, test_iuts)

--- a/tests/external_log_area/test_external_log_area.py
+++ b/tests/external_log_area/test_external_log_area.py
@@ -270,7 +270,7 @@ class TestExternalLogArea(unittest.TestCase):
             self.logger.info("STEP: Send a stop request that fails.")
             with self.assertRaises(LogAreaCheckinFailed):
                 self.logger.info(
-                    "STEP: Verify that the checkin method raises LogAreaCheckinFailed " "exception."
+                    "STEP: Verify that the checkin method raises LogAreaCheckinFailed exception."
                 )
                 provider.checkin(log_area)
 

--- a/tests/external_log_area/test_external_log_area.py
+++ b/tests/external_log_area/test_external_log_area.py
@@ -74,9 +74,7 @@ class TestExternalLogArea(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a start request.")
             start_id = provider.start(1, 2)
-            self.logger.info(
-                "STEP: Verify that the ID from the start request is returned."
-            )
+            self.logger.info("STEP: Verify that the ID from the start request is returned.")
             self.assertEqual(start_id, expected_start_id)
 
     def test_provider_start_http_exception(self):
@@ -105,9 +103,7 @@ class TestExternalLogArea(unittest.TestCase):
         )
         expected_start_id = "123"
 
-        with FakeServer(
-            ["bad_request", "ok"], [{}, {"id": expected_start_id}]
-        ) as server:
+        with FakeServer(["bad_request", "ok"], [{}, {"id": expected_start_id}]) as server:
             ruleset = {
                 "id": "test_provider_start_http_exception",
                 "start": {"host": server.host},
@@ -116,9 +112,7 @@ class TestExternalLogArea(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a start request that fails.")
             start_id = provider.start(1, 2)
-            self.logger.info(
-                "STEP: Verify that the start method tries again on HTTP errors."
-            )
+            self.logger.info("STEP: Verify that the start method tries again on HTTP errors.")
             self.assertGreaterEqual(server.nbr_of_requests, 2)
             self.assertEqual(start_id, expected_start_id)
 
@@ -158,9 +152,7 @@ class TestExternalLogArea(unittest.TestCase):
             self.logger.info("STEP: Send a start request which will never finish.")
 
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the start method raises TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the start method raises TimeoutError.")
                 provider.start(1, 2)
 
     def test_provider_stop(self):
@@ -278,8 +270,7 @@ class TestExternalLogArea(unittest.TestCase):
             self.logger.info("STEP: Send a stop request that fails.")
             with self.assertRaises(LogAreaCheckinFailed):
                 self.logger.info(
-                    "STEP: Verify that the checkin method raises LogAreaCheckinFailed "
-                    "exception."
+                    "STEP: Verify that the checkin method raises LogAreaCheckinFailed " "exception."
                 )
                 provider.checkin(log_area)
 
@@ -318,9 +309,7 @@ class TestExternalLogArea(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a stop request that fails.")
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the checkin method raises a TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the checkin method raises a TimeoutError.")
                 provider.checkin(log_area)
 
     def test_provider_status(self):
@@ -353,13 +342,9 @@ class TestExternalLogArea(unittest.TestCase):
             ruleset = {"id": "test_provider_status", "status": {"host": server.host}}
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a status request for a started log area provider."
-            )
+            self.logger.info("STEP: Send a status request for a started log area provider.")
             response = provider.wait("1")
-            self.logger.info(
-                "STEP: Verify that the wait method return response on DONE."
-            )
+            self.logger.info("STEP: Verify that the wait method return response on DONE.")
             self.assertEqual(response.get("test_id"), test_id)
 
     def test_provider_status_pending(self):
@@ -395,9 +380,7 @@ class TestExternalLogArea(unittest.TestCase):
             }
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a status request for a started log area provider."
-            )
+            self.logger.info("STEP: Send a status request for a started log area provider.")
             provider.wait("1")
             self.logger.info("STEP: Verify that the wait method waits on PENDING.")
             self.assertEqual(server.nbr_of_requests, len(responses))
@@ -428,22 +411,16 @@ class TestExternalLogArea(unittest.TestCase):
             }
         )
         description = "something failed!"
-        with FakeServer(
-            "ok", {"status": "FAILED", "description": description}
-        ) as server:
+        with FakeServer("ok", {"status": "FAILED", "description": description}) as server:
             ruleset = {
                 "id": "test_provider_status_failed",
                 "status": {"host": server.host},
             }
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a status request for a started log area provider."
-            )
+            self.logger.info("STEP: Send a status request for a started log area provider.")
             with self.assertRaises(LogAreaCheckoutFailed):
-                self.logger.info(
-                    "STEP: Verify that the wait method raises LogAreaCheckoutFailed."
-                )
+                self.logger.info("STEP: Verify that the wait method raises LogAreaCheckoutFailed.")
                 provider.wait("1")
 
     def test_provider_status_http_exceptions(self):
@@ -485,9 +462,7 @@ class TestExternalLogArea(unittest.TestCase):
                 }
                 self.logger.info("STEP: Initialize an external provider.")
                 provider = ExternalProvider(etos, jsontas, ruleset)
-                self.logger.info(
-                    "STEP: Send a status request for a started log area provider."
-                )
+                self.logger.info("STEP: Send a status request for a started log area provider.")
                 with self.assertRaises(exception):
                     self.logger.info(
                         "STEP: Verify that the wait method raises the correct exception."
@@ -528,9 +503,7 @@ class TestExternalLogArea(unittest.TestCase):
             provider = ExternalProvider(etos, jsontas, ruleset)
             self.logger.info("STEP: Send a status request that times out.")
             with self.assertRaises(TimeoutError):
-                self.logger.info(
-                    "STEP: Verify that the wait method raises TimeoutError."
-                )
+                self.logger.info("STEP: Verify that the wait method raises TimeoutError.")
                 provider.wait("1")
 
     def test_request_and_wait(self):
@@ -582,9 +555,7 @@ class TestExternalLogArea(unittest.TestCase):
             }
             self.logger.info("STEP: Initialize an external provider.")
             provider = ExternalProvider(etos, jsontas, ruleset)
-            self.logger.info(
-                "STEP: Send a checkout request via the external log area provider."
-            )
+            self.logger.info("STEP: Send a checkout request via the external log area provider.")
             log_areas = provider.request_and_wait_for_log_areas()
             self.logger.info(
                 "STEP: Verify that the provider returns a list of checked out log areas."

--- a/tests/library/fake_request.py
+++ b/tests/library/fake_request.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A fake request and response structure that can be used in tests."""
+from falcon.errors import MediaNotFoundError
 
 
 class FakeRequest:  # pylint:disable=too-few-public-methods
@@ -37,11 +38,10 @@ class FakeRequest:  # pylint:disable=too-few-public-methods
         """
         return self.fake_params.get(name)
 
-    @property
-    def media(self):
+    def get_media(self):
         """Media is used for POST requests."""
         if self.force_media_none:
-            return None
+            raise MediaNotFoundError("")
         return self.fake_params
 
 

--- a/tests/library/graphql_handler.py
+++ b/tests/library/graphql_handler.py
@@ -73,12 +73,8 @@ class GraphQLHandler(BaseHTTPRequestHandler):
                                     {
                                         "links": {
                                             "__typename": "ArtifactCreated",
-                                            "data": {
-                                                "identity": "pkg:test/environment-provider"
-                                            },
-                                            "meta": {
-                                                "id": self.tercc["links"][0]["target"]
-                                            },
+                                            "data": {"identity": "pkg:test/environment-provider"},
+                                            "meta": {"id": self.tercc["links"][0]["target"]},
                                         }
                                     }
                                 ],
@@ -98,13 +94,7 @@ class GraphQLHandler(BaseHTTPRequestHandler):
         return {
             "data": {
                 "activityTriggered": {
-                    "edges": [
-                        {
-                            "node": {
-                                "meta": {"id": "2ec8b7db-1cdd-417a-9cf8-9cec370b117f"}
-                            }
-                        }
-                    ]
+                    "edges": [{"node": {"meta": {"id": "2ec8b7db-1cdd-417a-9cf8-9cec370b117f"}}}]
                 }
             }
         }
@@ -115,11 +105,7 @@ class GraphQLHandler(BaseHTTPRequestHandler):
         :return: A graphql response with an artifact published event.
         :rtype dict
         """
-        return {
-            "data": {
-                "artifactPublished": {"edges": [{"node": {"data": {"locations": []}}}]}
-            }
-        }
+        return {"data": {"artifactPublished": {"edges": [{"node": {"data": {"locations": []}}}]}}}
 
     def test_suite_started(self):
         """Create a fake test suite started to simulate ESR.
@@ -130,13 +116,7 @@ class GraphQLHandler(BaseHTTPRequestHandler):
         return {
             "data": {
                 "testSuiteStarted": {
-                    "edges": [
-                        {
-                            "node": {
-                                "meta": {"id": "3d1cab0e-dacb-4991-afac-7581eea4a3df"}
-                            }
-                        }
-                    ]
+                    "edges": [{"node": {"meta": {"id": "3d1cab0e-dacb-4991-afac-7581eea4a3df"}}}]
                 }
             }
         }

--- a/tests/tercc.py
+++ b/tests/tercc.py
@@ -38,9 +38,7 @@ TERCC_SUB_SUITES = {
                             {"key": "EXECUTE", "value": []},
                             {
                                 "key": "CHECKOUT",
-                                "value": [
-                                    "git clone https://github.com/eiffel-community/etos.git"
-                                ],
+                                "value": ["git clone https://github.com/eiffel-community/etos.git"],
                             },
                             {
                                 "key": "TEST_RUNNER",
@@ -62,9 +60,7 @@ TERCC_SUB_SUITES = {
                             {"key": "EXECUTE", "value": []},
                             {
                                 "key": "CHECKOUT",
-                                "value": [
-                                    "git clone https://github.com/eiffel-community/etos.git"
-                                ],
+                                "value": ["git clone https://github.com/eiffel-community/etos.git"],
                             },
                             {
                                 "key": "TEST_RUNNER",
@@ -108,9 +104,7 @@ TERCC = {
                             {"key": "EXECUTE", "value": []},
                             {
                                 "key": "CHECKOUT",
-                                "value": [
-                                    "git clone https://github.com/eiffel-community/etos.git"
-                                ],
+                                "value": ["git clone https://github.com/eiffel-community/etos.git"],
                             },
                             {
                                 "key": "TEST_RUNNER",
@@ -154,9 +148,7 @@ TERCC_PERMUTATION = {
                             {"key": "EXECUTE", "value": []},
                             {
                                 "key": "CHECKOUT",
-                                "value": [
-                                    "git clone https://github.com/eiffel-community/etos.git"
-                                ],
+                                "value": ["git clone https://github.com/eiffel-community/etos.git"],
                             },
                             {
                                 "key": "TEST_RUNNER",
@@ -184,9 +176,7 @@ TERCC_PERMUTATION = {
                             {"key": "EXECUTE", "value": []},
                             {
                                 "key": "CHECKOUT",
-                                "value": [
-                                    "git clone https://github.com/eiffel-community/etos.git"
-                                ],
+                                "value": ["git clone https://github.com/eiffel-community/etos.git"],
                             },
                             {
                                 "key": "TEST_RUNNER",

--- a/tests/test_environment_provider.py
+++ b/tests/test_environment_provider.py
@@ -137,9 +137,7 @@ class TestEnvironmentProvider(unittest.TestCase):
         database = FakeDatabase()
         database.write(f"EnvironmentProvider:{suite_id}", json.dumps(tercc))
         database.write(f"EnvironmentProvider:{suite_id}Dataset", json.dumps({}))
-        database.write(
-            f"EnvironmentProvider:{suite_id}IUTProvider", json.dumps(IUT_PROVIDER)
-        )
+        database.write(f"EnvironmentProvider:{suite_id}IUTProvider", json.dumps(IUT_PROVIDER))
         database.write(
             f"EnvironmentProvider:{suite_id}ExecutionSpaceProvider",
             json.dumps(EXECUTION_SPACE_PROVIDER),
@@ -188,9 +186,7 @@ class TestEnvironmentProvider(unittest.TestCase):
         database = FakeDatabase()
         database.write(f"EnvironmentProvider:{suite_id}", json.dumps(tercc))
         database.write(f"EnvironmentProvider:{suite_id}Dataset", json.dumps({}))
-        database.write(
-            f"EnvironmentProvider:{suite_id}IUTProvider", json.dumps(IUT_PROVIDER)
-        )
+        database.write(f"EnvironmentProvider:{suite_id}IUTProvider", json.dumps(IUT_PROVIDER))
         database.write(
             f"EnvironmentProvider:{suite_id}ExecutionSpaceProvider",
             json.dumps(EXECUTION_SPACE_PROVIDER),
@@ -242,9 +238,7 @@ class TestEnvironmentProvider(unittest.TestCase):
         database = FakeDatabase()
         database.write(f"EnvironmentProvider:{suite_id}", json.dumps(tercc))
         database.write(f"EnvironmentProvider:{suite_id}Dataset", json.dumps({}))
-        database.write(
-            f"EnvironmentProvider:{suite_id}IUTProvider", json.dumps(IUT_PROVIDER)
-        )
+        database.write(f"EnvironmentProvider:{suite_id}IUTProvider", json.dumps(IUT_PROVIDER))
         database.write(
             f"EnvironmentProvider:{suite_id}ExecutionSpaceProvider",
             json.dumps(EXECUTION_SPACE_PROVIDER),

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -53,9 +53,7 @@ class TestSubSuite(unittest.TestCase):
         response = FakeResponse()
         SubSuite(database).on_get(request, response)
 
-        self.logger.info(
-            "STEP: Verify that the sub suite endpoint responds with a sub suite."
-        )
+        self.logger.info("STEP: Verify that the sub suite endpoint responds with a sub suite.")
         self.assertDictEqual(response.fake_responses.get("media"), sub_suite)
 
     def test_get_no_id(self):
@@ -72,8 +70,6 @@ class TestSubSuite(unittest.TestCase):
         request = FakeRequest()
         request.fake_params["id"] = "thisonedoesnotexist"
         response = FakeResponse()
-        self.logger.info(
-            "STEP: Verify that the sub suite endpoint responds with HTTPNotFound."
-        )
+        self.logger.info("STEP: Verify that the sub suite endpoint responds with HTTPNotFound.")
         with self.assertRaises(falcon.HTTPNotFound):
             SubSuite(FakeDatabase).on_get(request, response)

--- a/tests/test_webserver_configure.py
+++ b/tests/test_webserver_configure.py
@@ -89,13 +89,9 @@ class TestConfigure(unittest.TestCase):
         self.logger.info("STEP: Send a GET request to the configure endpoint.")
         Configure(database).on_get(request, response)
 
-        self.logger.info(
-            "STEP: Verify that the configuration is the same as in the database."
-        )
+        self.logger.info("STEP: Verify that the configuration is the same as in the database.")
         self.assertEqual(response.status, falcon.HTTP_200)
-        self.assertDictEqual(
-            response.media.get("iut_provider", {}), test_iut_provider["iut"]
-        )
+        self.assertDictEqual(response.media.get("iut_provider", {}), test_iut_provider["iut"])
         self.assertDictEqual(
             response.media.get("log_area_provider", {}), test_log_area_provider["log"]
         )
@@ -118,9 +114,7 @@ class TestConfigure(unittest.TestCase):
         database = FakeDatabase()
         response = FakeResponse()
         request = FakeRequest()
-        self.logger.info(
-            "STEP: Send a GET request to the configure endpoint without suite id."
-        )
+        self.logger.info("STEP: Send a GET request to the configure endpoint without suite id.")
         with self.assertRaises(falcon.HTTPBadRequest):
             self.logger.info("STEP: Verify that a BadRequest is returned.")
             Configure(database).on_get(request, response)
@@ -179,9 +173,7 @@ class TestConfigure(unittest.TestCase):
         request = FakeRequest()
         request.fake_params = {
             "iut_provider": test_iut_provider["iut"]["id"],
-            "execution_space_provider": test_execution_space_provider[
-                "execution_space"
-            ]["id"],
+            "execution_space_provider": test_execution_space_provider["execution_space"]["id"],
             "log_area_provider": test_log_area_provider["log"]["id"],
             "dataset": {},
             "suite_id": test_suite_id,
@@ -189,26 +181,18 @@ class TestConfigure(unittest.TestCase):
         self.logger.info("STEP: Send a configure request to use those providers.")
         Configure(database).on_post(request, response)
 
-        self.logger.info(
-            "STEP: Verify that the configuration matches the providers in database."
-        )
+        self.logger.info("STEP: Verify that the configuration matches the providers in database.")
         self.assertEqual(response.status, falcon.HTTP_200)
         stored_iut_provider = json.loads(
             database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "IUTProvider")
         )
         self.assertDictEqual(stored_iut_provider, test_iut_provider)
         stored_execution_space_provider = json.loads(
-            database.reader.hget(
-                f"EnvironmentProvider:{test_suite_id}", "ExecutionSpaceProvider"
-            )
+            database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "ExecutionSpaceProvider")
         )
-        self.assertDictEqual(
-            stored_execution_space_provider, test_execution_space_provider
-        )
+        self.assertDictEqual(stored_execution_space_provider, test_execution_space_provider)
         stored_log_area_provider = json.loads(
-            database.reader.hget(
-                f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider"
-            )
+            database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider")
         )
         self.assertDictEqual(stored_log_area_provider, test_log_area_provider)
         stored_dataset = json.loads(
@@ -269,9 +253,7 @@ class TestConfigure(unittest.TestCase):
         request = FakeRequest()
         test_params = {
             "iut_provider": test_iut_provider["iut"]["id"],
-            "execution_space_provider": test_execution_space_provider[
-                "execution_space"
-            ]["id"],
+            "execution_space_provider": test_execution_space_provider["execution_space"]["id"],
             "log_area_provider": test_log_area_provider["log"]["id"],
             "dataset": {},
         }
@@ -298,9 +280,7 @@ class TestConfigure(unittest.TestCase):
 
             self.logger.info("STEP: Verify that it was not possible to configure.")
             self.assertIsNone(
-                database.reader.hget(
-                    f"EnvironmentProvider:{test_suite_id}", "IUTProvider"
-                )
+                database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "IUTProvider")
             )
             self.assertIsNone(
                 database.reader.hget(
@@ -308,9 +288,7 @@ class TestConfigure(unittest.TestCase):
                 )
             )
             self.assertIsNone(
-                database.reader.hget(
-                    f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider"
-                )
+                database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "LogAreaProvider")
             )
             self.assertIsNone(
                 database.reader.hget(f"EnvironmentProvider:{test_suite_id}", "Dataset")

--- a/tests/test_webserver_environment.py
+++ b/tests/test_webserver_environment.py
@@ -147,13 +147,9 @@ class TestEnvironment(unittest.TestCase):
         environment = Webserver(database, celery_worker)
         environment.on_get(request, response)
 
-        self.logger.info(
-            "STEP: Verify that the status for the environment was returned."
-        )
+        self.logger.info("STEP: Verify that the status for the environment was returned.")
         self.assertEqual(response.status, falcon.HTTP_200)
-        self.assertDictEqual(
-            response.media, {"status": test_status, "result": test_result}
-        )
+        self.assertDictEqual(response.media, {"status": test_status, "result": test_result})
 
     @patch("environment_provider_api.backend.environment.get_environment")
     def test_get_environment(self, get_environment_mock):
@@ -188,10 +184,6 @@ class TestEnvironment(unittest.TestCase):
         environment = Webserver(database, celery_worker)
         environment.on_post(request, response)
 
-        self.logger.info(
-            "STEP: Verify that the environment provider gets an environment."
-        )
+        self.logger.info("STEP: Verify that the environment provider gets an environment.")
         self.assertEqual(response.media, {"result": "success", "data": {"id": task_id}})
-        get_environment_mock.delay.assert_called_once_with(
-            suite_id, suite_runner_ids.split(",")
-        )
+        get_environment_mock.delay.assert_called_once_with(suite_id, suite_runner_ids.split(","))

--- a/tests/test_webserver_register.py
+++ b/tests/test_webserver_register.py
@@ -69,9 +69,7 @@ class TestRegister(unittest.TestCase):
         self.logger.info("STEP: Send a register request for new providers.")
         Register(fake_database).on_post(fake_request, fake_response)
 
-        self.logger.info(
-            "STEP: Verify that the new providers were registered in the database."
-        )
+        self.logger.info("STEP: Verify that the new providers were registered in the database.")
         self.assertEqual(fake_response.fake_responses.get("status"), falcon.HTTP_204)
         stored_execution_space_provider = json.loads(
             fake_database.reader.hget(
@@ -90,9 +88,7 @@ class TestRegister(unittest.TestCase):
         )
         self.assertDictEqual(stored_log_area_provider, test_log_area_provider)
         stored_iut_provider = json.loads(
-            fake_database.reader.hget(
-                "EnvironmentProvider:IUTProviders", "iut_provider_test"
-            )
+            fake_database.reader.hget("EnvironmentProvider:IUTProviders", "iut_provider_test")
         )
         self.assertDictEqual(stored_iut_provider, test_iut_provider)
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py3,black,pylint,pydocstyle
 
 [testenv]
+setenv = ETOS_ENABLE_SENDING_LOGS=false
 deps =
     -r{toxinidir}/test-requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
 deps =
     black
 commands =
-    black --check --diff .
+    black --check --diff -l 100 .
 
 [testenv:pylint]
 deps =


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#148

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Send user logs to RabbitMQ for the ETOS client.
Also had to update a few packages for this to work so I updated everything.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I went for the least amount of logging that I felt gave something. There might still be some messages that can be added, but for now I just wanted to add support for it and send something. This makes it easier to update which messages to send in the future.

### Benefits
<!-- What benefits will be realized by the change? -->
This will give some information on the goings-on inside of the environment provider for our clients.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Nothing really.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
