### PR TITLE
Add some failure information when failing to create environment

### DIFF
--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -549,6 +549,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         except Exception as exception:  # pylint:disable=broad-except
             self.cleanup()
             traceback.print_exc()
+            self.logger.error("Failed creating environment for test. %r", extra={"user_log": True})
             return {"error": str(exception), "details": traceback.format_exc()}
         finally:
             if self.etos.publisher is not None and not self.etos.debug.disable_sending_events:


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#148

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add some more failure information when failing to create a full environment

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits
<!-- What benefits will be realized by the change? -->
Better information when stuff goes wrong

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
There could be duplicate information if an external provider also gives the failure information, but I don't think that's such a big problem.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
