### PR TITLE
Load providers from disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/*
 */.ipynb_checkpoints/*
 *.tags
 .DS_Store
+.tags
 
 # Project files
 .ropeproject

--- a/src/environment_provider_api/webserver.py
+++ b/src/environment_provider_api/webserver.py
@@ -19,6 +19,7 @@ import logging
 import traceback
 import json
 from uuid import UUID
+from pathlib import Path
 import falcon
 
 from etos_lib.etos import ETOS
@@ -282,6 +283,8 @@ class Configure:
 class Register:  # pylint:disable=too-few-public-methods
     """Register one or several new providers to the environment provider."""
 
+    logger = logging.getLogger(__name__)
+
     def __init__(self, database):
         """Init with a db class.
 
@@ -289,6 +292,42 @@ class Register:  # pylint:disable=too-few-public-methods
         :type database: class
         """
         self.database = database
+        self.load_providers_from_disk()
+
+    def providers(self, directory):
+        """Read provider json files from a directory.
+
+        :param directory: Directory to read provider json files from.
+        :type directory: str
+        :return: An iterator of the json files.
+        :rtype: Iterator[dict]
+        """
+        try:
+            filenames = os.listdir(directory)
+        except FileNotFoundError:
+            return
+        for provider_filename in filenames:
+            if not directory.joinpath(provider_filename).is_file():
+                self.logger.warn("Not a file: %r", provider_filename)
+                continue
+            with directory.joinpath(provider_filename).open() as provider_file:
+                yield json.load(provider_file)
+
+    def load_providers_from_disk(self):
+        """Register provider files from file system, should environment variables be set."""
+        etos = ETOS("ETOS Environment Provider", os.getenv("HOSTNAME"), "Environment Provider")
+        jsontas = JsonTas()
+        registry = ProviderRegistry(etos, jsontas, self.database())
+
+        if os.getenv("EXECUTION_SPACE_PROVIDERS"):
+            for provider in self.providers(Path(os.getenv("EXECUTION_SPACE_PROVIDERS"))):
+                register(registry, execution_space_provider=provider)
+        if os.getenv("LOG_AREA_PROVIDERS"):
+            for provider in self.providers(Path(os.getenv("LOG_AREA_PROVIDERS"))):
+                register(registry, log_area_provider=provider)
+        if os.getenv("IUT_PROVIDERS"):
+            for provider in self.providers(Path(os.getenv("IUT_PROVIDERS"))):
+                register(registry, iut_provider=provider)
 
     def on_post(self, request, response):
         """Register a new provider.


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#50

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Loading the providers from files will allow us to create them as secrets in Kubernetes and mount them in.
This way the passwords in these files can be secured using SealedSecret or something similar.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I was thinking about creating a custom resource for providers, but that would be much larger undertaking that we can look at in the future instead.

### Benefits
<!-- What benefits will be realized by the change? -->
This will enable secure passwords in the provider files.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None?

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
