### PR TITLE
Remove logs that may contain sensitive data

### DIFF
--- a/src/environment_provider/lib/registry.py
+++ b/src/environment_provider/lib/registry.py
@@ -102,7 +102,6 @@ class ProviderRegistry:
         """
         self.logger.info("Getting log area provider %r", provider_id)
         provider = self.database.reader.hget("EnvironmentProvider:LogAreaProviders", provider_id)
-        self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
         return None
@@ -119,7 +118,6 @@ class ProviderRegistry:
         """
         self.logger.info("Getting iut provider %r", provider_id)
         provider = self.database.reader.hget("EnvironmentProvider:IUTProviders", provider_id)
-        self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
         return None
@@ -138,7 +136,6 @@ class ProviderRegistry:
         provider = self.database.reader.hget(
             "EnvironmentProvider:ExecutionSpaceProviders", provider_id
         )
-        self.logger.debug(provider)
         if provider:
             return json.loads(provider, object_pairs_hook=OrderedDict)
         return None
@@ -150,7 +147,7 @@ class ProviderRegistry:
         :type ruleset: dict
         """
         data = self.validate(ruleset, log_area_provider_schema(ruleset))
-        self.logger.info("Registering %r", data)
+        self.logger.info("Registering %r", data["log"]["id"])
         self.database.writer.hdel("EnvironmentProvider:LogAreaProviders", data["log"]["id"])
         self.database.writer.hset(
             "EnvironmentProvider:LogAreaProviders", data["log"]["id"], json.dumps(data)
@@ -163,7 +160,7 @@ class ProviderRegistry:
         :type ruleset: dict
         """
         data = self.validate(ruleset, iut_provider_schema(ruleset))
-        self.logger.info("Registering %r", data)
+        self.logger.info("Registering %r", data["iut"]["id"])
         self.database.writer.hdel("EnvironmentProvider:IUTProviders", data["iut"]["id"])
         self.database.writer.hset(
             "EnvironmentProvider:IUTProviders", data["iut"]["id"], json.dumps(data)
@@ -176,7 +173,7 @@ class ProviderRegistry:
         :type ruleset: dict
         """
         data = self.validate(ruleset, execution_space_provider_schema(ruleset))
-        self.logger.info("Registering %r", data)
+        self.logger.info("Registering %r", data["execution_space"]["id"])
         self.database.writer.hdel(
             "EnvironmentProvider:ExecutionSpaceProviders", data["execution_space"]["id"]
         )
@@ -197,7 +194,6 @@ class ProviderRegistry:
         provider_json = self.database.reader.hget(
             f"EnvironmentProvider:{suite_id}", "ExecutionSpaceProvider"
         )
-        self.logger.info(provider_json)
         if provider_json:
             provider = ExecutionSpaceProvider(
                 self.etos,
@@ -217,7 +213,6 @@ class ProviderRegistry:
         :rtype: :obj:`environment_provider.iut.iut_provider.IutProvider`
         """
         provider_str = self.database.reader.hget(f"EnvironmentProvider:{suite_id}", "IUTProvider")
-        self.logger.info(provider_str)
         if provider_str:
             provider_json = json.loads(provider_str, object_pairs_hook=OrderedDict)
             provider = IutProvider(self.etos, self.jsontas, provider_json.get("iut"))
@@ -236,7 +231,6 @@ class ProviderRegistry:
         provider_json = self.database.reader.hget(
             f"EnvironmentProvider:{suite_id}", "LogAreaProvider"
         )
-        self.logger.info(provider_json)
         if provider_json:
             provider = LogAreaProvider(
                 self.etos,


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#50

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Remove the logs that show the data from provider JSON files. The provider JSON files may contain password that should be encrypted and should not be logged.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I would love to have the data encrypted before adding it to the environment provider, but that cannot be guaranteed sadly.

### Benefits
<!-- What benefits will be realized by the change? -->
Less sensitive data.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
