### PR TITLE
Change ENVIRONMENT_ID so as to not conflict with identifier

### DIFF
--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -303,8 +303,9 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         # In a valid sub suite all of these keys must exist
         # making this a safe assumption
         identifier = sub_suite["executor"]["instructions"]["identifier"]
+        event_id = sub_suite["executor"]["instructions"]["environment"]["ENVIRONMENT_ID"]
         event = EiffelEnvironmentDefinedEvent()
-        event.meta.event_id = identifier
+        event.meta.event_id = event_id
         self.etos.events.send(
             event,
             {"CONTEXT": self.etos.config.get("environment_provider_context")},

--- a/src/execution_space_provider/utilities/instructions.py
+++ b/src/execution_space_provider/utilities/instructions.py
@@ -34,7 +34,7 @@ class Instructions(DataStructure):  # pylint:disable=too-few-public-methods
         instructions["parameters"].update(self.data.get("parameters", {}))
         instructions["image"] = self.data.get("image", instructions["image"])
         instructions["identifier"] = str(uuid4())
-        instructions["environment"]["ENVIRONMENT_ID"] = instructions["identifier"]
+        instructions["environment"]["ENVIRONMENT_ID"] = str(uuid4())
 
         # TODO: This shall be removed when ETR uses the EnvironmentDefined event.
         instructions["environment"]["SUB_SUITE_URL"] = (


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes a problem with: #79 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make sure that we still save the sub suite under the identifier key in Redis.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We are going to fix this so that it is no longer necessary in the ETR, but I don't want to break the environment provider before fixing it in ETR.

### Benefits
<!-- What benefits will be realized by the change? -->
This will make sure that we still work while working on ETR.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None. But we really should clean up these redis writes later, when we don't need them anymore.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
