### PR TITLE
Add kustomization manifest files

### DIFF
--- a/manifests/base/api/deployment.yaml
+++ b/manifests/base/api/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etos-environment-provider
+  labels:
+    app.kubernetes.io/name: etos-environment-provider
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: environment-provider-api
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: etos-environment-provider
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: etos-environment-provider
+    spec:
+      serviceAccountName: etos-environment-provider
+      containers:
+        - name: etos-environment-provider
+          image: "registry.nordix.org/eiffel/etos-environment-provider:2.2.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /?id=healthcheck
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /?id=healthcheck
+              port: http

--- a/manifests/base/api/service-account.yaml
+++ b/manifests/base/api/service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etos-environment-provider
+  labels:
+    app.kubernetes.io/name: etos-environment-provider
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: environment-provider-api

--- a/manifests/base/api/service.yaml
+++ b/manifests/base/api/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etos-environment-provider
+  labels:
+    app.kubernetes.io/name: etos-environment-provider
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: environment-provider-api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: etos-environment-provider

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - api/service-account.yaml
+  - api/deployment.yaml
+  - api/service.yaml
+  - worker/service-account.yaml
+  - worker/deployment.yaml
+
+
+# By generating the configmap it will get a unique name on each apply
+# this name is also set on the deployment. This means that the pods
+# will restart with the new configmap when changes are made. Making
+# it so we do not have to do rollout restart every time.
+configMapGenerator:
+  - name: etos-environment-provider-worker
+    literals:
+      - ETR_VERSION="3.2.0"
+  - name: etos-environment-provider

--- a/manifests/base/worker/deployment.yaml
+++ b/manifests/base/worker/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etos-environment-provider-worker
+  labels:
+    app.kubernetes.io/name: etos-environment-provider-worker
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: environment-provider-worker
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: etos-environment-provider-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: etos-environment-provider-worker
+    spec:
+      serviceAccountName: etos-environment-provider-worker
+      containers:
+        - name: etos-environment-provider-worker
+          image: "registry.nordix.org/eiffel/etos-environment-provider-worker:2.2.1"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+          - configMapRef:
+              name: etos-environment-provider-worker
+      # This grace period ensures that the environment provider will wait
+      # for the environment checkouts to complete before shutting down.
+      terminationGracePeriodSeconds: 4250

--- a/manifests/base/worker/service-account.yaml
+++ b/manifests/base/worker/service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etos-environment-provider-worker
+  labels:
+    app.kubernetes.io/name: etos-environment-provider-worker
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: environment-provider-worker


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#188

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add manifest files to environment provider

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could keep all manifest files in the ETOS repository, but I think letting each component decide on its own versions and having the ETOS repository set the release versions is the correct way.

### Benefits
<!-- What benefits will be realized by the change? -->
Kustomize is easier to handle and built into kubectl

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None really

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
