### PR TITLE
Send default instructions to external provider

### DIFF
--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -166,7 +166,9 @@ class ExternalProvider:
                 "ETOS_GRAPHQL_SERVER": self.etos.debug.graphql_server,
                 "ETOS_API": self.etos.debug.etos_api,
                 "ETOS_ENVIRONMENT_PROVIDER": self.etos.debug.environment_provider,
-                "ETR_VERSION": os.getenv("ETR_VERSION",)
+                "ETR_VERSION": os.getenv(
+                    "ETR_VERSION",
+                ),
             },
             "artifact_id": self.dataset.get("artifact_id"),
             "artifact_created": self.dataset.get("artifact_created"),

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -21,6 +21,7 @@ import logging
 from copy import deepcopy
 
 import requests
+from environment_provider.lib.encrypt import encrypt
 
 from ..exceptions import (
     ExecutionSpaceCheckinFailed,
@@ -142,10 +143,31 @@ class ExternalProvider:
         :rtype: str
         """
         self.logger.debug("Start external execution space provider")
+        rabbitmq = self.etos.config.get("rabbitmq")
+        rabbitmq_password = rabbitmq.get("password")
+        if os.getenv("ETOS_ENCRYPTION_KEY") is not None:
+            rabbitmq_password = encrypt(
+                rabbitmq_password.encode(), os.getenv("ETOS_ENCRYPTION_KEY")
+            )
         data = {
             "minimum_amount": minimum_amount,
             "maximum_amount": maximum_amount,
             "identity": self.identity.to_string(),
+            "test_runner": self.dataset.get("test_runner"),
+            "environment": {
+                "RABBITMQ_HOST": rabbitmq.get("host"),
+                "RABBITMQ_USERNAME": rabbitmq.get("username"),
+                "RABBITMQ_PASSWORD": rabbitmq_password,
+                "RABBITMQ_EXCHANGE": rabbitmq.get("exchange"),
+                "RABBITMQ_PORT": rabbitmq.get("port"),
+                "RABBITMQ_VHOST": rabbitmq.get("vhost"),
+                "RABBITMQ_SSL": rabbitmq.get("ssl"),
+                "SOURCE_HOST": self.etos.config.get("source").get("host"),
+                "ETOS_GRAPHQL_SERVER": self.etos.debug.graphql_server,
+                "ETOS_API": self.etos.debug.etos_api,
+                "ETOS_ENVIRONMENT_PROVIDER": self.etos.debug.environment_provider,
+                "ETR_VERSION": os.getenv("ETR_VERSION",)
+            },
             "artifact_id": self.dataset.get("artifact_id"),
             "artifact_created": self.dataset.get("artifact_created"),
             "artifact_published": self.dataset.get("artifact_published"),


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Send the default instructions to external providers.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I thought about sending them in using the JSON structure, but the defaults are added from the environment provider.
There's also the `parameters` field in the instructions which is not passed to the provider, since they have no defaults yet.

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow the external provider to work better with the environment provider, without many duplicate variables.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
We are passing a lot of information.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
