### PR TITLE
Remove subsuite loop from release_full_environment

### DIFF
--- a/src/environment_provider_api/backend/environment.py
+++ b/src/environment_provider_api/backend/environment.py
@@ -134,11 +134,10 @@ def release_full_environment(etos: ETOS, jsontas: JsonTas, suite_id: str) -> tup
     registry = ProviderRegistry(etos, jsontas, suite_id)
     for suite, metadata in registry.testrun.join("suite").read_all():
         suite = json.loads(suite)
-        for sub_suite in suite.get("sub_suites", []):
-            try:
-                failure = release_environment(etos, jsontas, registry, sub_suite)
-            except json.JSONDecodeError as exception:
-                failure = exception
+        try:
+            failure = release_environment(etos, jsontas, registry, suite)
+        except json.JSONDecodeError as exception:
+            failure = exception
         ETCDPath(metadata.get("key")).delete()
     registry.testrun.delete_all()
 

--- a/tests/backend/test_environment.py
+++ b/tests/backend/test_environment.py
@@ -144,13 +144,9 @@ class TestEnvironmentBackend(unittest.TestCase):
             f"/testrun/{test_suite_id}/suite/fakeid/subsuite/fakeid/suite",
             json.dumps(
                 {
-                    "sub_suites": [
-                        {
-                            "iut": iut,
-                            "executor": executor,
-                            "log_area": log_area,
-                        }
-                    ]
+                    "iut": iut,
+                    "executor": executor,
+                    "log_area": log_area,
                 }
             ),
         )
@@ -227,13 +223,9 @@ class TestEnvironmentBackend(unittest.TestCase):
             f"/testrun/{test_suite_id}/suite/fakeid/subsuite/fakeid/suite",
             json.dumps(
                 {
-                    "sub_suites": [
-                        {
-                            "iut": iut,
-                            "executor": executor,
-                            "log_area": log_area,
-                        }
-                    ]
+                    "iut": iut,
+                    "executor": executor,
+                    "log_area": log_area,
                 }
             ),
         )

--- a/tests/test_environment_provider.py
+++ b/tests/test_environment_provider.py
@@ -348,6 +348,20 @@ class TestEnvironmentProvider(unittest.TestCase):
         suite_runner_ids = ["14ffc8d7-572a-4f2f-9382-923de2bcf50a"]
         task_id = "d9689ea5-837b-48c1-87b1-3de122b3f2fe"
         database.put(f"/environment/{task_id}/suite-id", suite_id)
+        database.put(
+            f"/environment/provider/iut/{IUT_PROVIDER['iut']['id']}", json.dumps(IUT_PROVIDER)
+        )
+        database.put(
+            f"/environment/provider/log-area/{LOG_AREA_PROVIDER['log']['id']}",
+            json.dumps(LOG_AREA_PROVIDER),
+        )
+        database.put(
+            (
+                "/environment/provider/execution-space/"
+                f"{EXECUTION_SPACE_PROVIDER['execution_space']['id']}"
+            ),
+            json.dumps(EXECUTION_SPACE_PROVIDER),
+        )
         database.put(f"/testrun/{suite_id}/environment-provider/task-id", task_id)
 
         database.put(f"/testrun/{suite_id}/tercc", json.dumps(tercc))

--- a/tests/test_webserver_environment.py
+++ b/tests/test_webserver_environment.py
@@ -107,13 +107,9 @@ class TestEnvironment(unittest.TestCase):
             {
                 "suites": [
                     {
-                        "sub_suites": [
-                            {
-                                "iut": iut,
-                                "executor": executor,
-                                "log_area": log_area,
-                            }
-                        ]
+                        "iut": iut,
+                        "executor": executor,
+                        "log_area": log_area,
                     }
                 ]
             },


### PR DESCRIPTION
### Applicable Issues

- [Abort running suites using DELETE request](https://github.com/eiffel-community/etos/issues/209)

### Description of the Change

The "sub_suites" is not a valid key. The response was empty, and therefore the sub_suite loop was never executed. This prevented environment checkin from functioning properly.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com