### PR TITLE
Make sure we do all in our power to release an environment

### DIFF
--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -25,7 +25,7 @@ from etos_lib import ETOS
 from etos_lib.lib.http import Http
 from jsontas.jsontas import JsonTas
 from packageurl import PackageURL
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError as RequestsConnectionError
 from urllib3.util import Retry
 
 from environment_provider.lib.encrypt import encrypt
@@ -132,6 +132,11 @@ class ExternalProvider:
                     raise ExecutionSpaceCheckinFailed(
                         f"Unable to check in {execution_spaces} " f"({response.get('error')})"
                     )
+            except RequestsConnectionError as error:
+                if "connection refused" in str(error).lower():
+                    self.logger.error("Error connecting to %r: %r", host, error)
+                    continue
+                raise
             except ConnectionError:
                 self.logger.error("Error connecting to %r", host)
                 continue

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -25,7 +25,7 @@ from etos_lib import ETOS
 from etos_lib.lib.http import Http
 from jsontas.jsontas import JsonTas
 from packageurl import PackageURL
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError as RequestsConnectionError
 from urllib3.util import Retry
 
 from ..exceptions import LogAreaCheckinFailed, LogAreaCheckoutFailed, LogAreaNotAvailable
@@ -126,6 +126,11 @@ class ExternalProvider:
                     raise LogAreaCheckinFailed(
                         f"Unable to check in {log_areas} ({response.get('error')})"
                     )
+            except RequestsConnectionError as error:
+                if "connection refused" in str(error).lower():
+                    self.logger.error("Error connecting to %r: %r", host, error)
+                    continue
+                raise
             except ConnectionError:
                 self.logger.error("Error connecting to %r", host)
                 continue


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
None

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Always retry stop requests to external providers even if they receive connection refused errors.
If a provider is shutting down due to a restart, then we need to retry the stop request as to not leave any environment dangling after an ETOS testrun.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
We could do a deeper analysis of the actual problem, but I don't really know how to do that without any sort of health-check mechanisms. And the restarting of the provider service is a difficult problem to detect.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
If the retry timer is long, then we will hang until that timer expires in a case where the provider service is not expected to respond. However, since we should've already sent a Start and several Status requests to the service I think we can, relatively, safely assume that it should be up and running and this error is just an intermittent problem.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
