### PR TITLE
Change default value for maximum amount

### DIFF
--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -424,7 +424,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
                 maximum_amount=self.dataset.get(
                     "maximum_amount",
                     os.getenv(
-                        "ETOS_MAX_PARALELL",
+                        "ETOS_MAX_PARALLEL",
                         self.etos.config.get("TOTAL_TEST_COUNT"),
                     ),
                 ),

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -424,7 +424,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
                 maximum_amount=self.dataset.get(
                     "maximum_amount",
                     os.getenv(
-                        "ETOS_MAX_PARALLEL",
+                        "ETOS_MAX_PARALLEL_IUTS",
                         self.etos.config.get("TOTAL_TEST_COUNT"),
                     ),
                 ),

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -418,17 +418,18 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         timeout = self.checkout_timeout()
         while time.time() < timeout:
             self.set_total_test_count_and_test_runners(test_runners)
-
-            with self.tracer.start_as_current_span("request_iuts", kind=SpanKind.CLIENT) as span:
-                # Check out and assign IUTs to test runners.
-                iuts = self.iut_provider.wait_for_and_checkout_iuts(
-                    minimum_amount=1,
-                    maximum_amount=self.dataset.get(
-                        "maximum_amount", self.etos.config.get("TOTAL_TEST_COUNT")
+            # Check out and assign IUTs to test runners.
+            iuts = self.iut_provider.wait_for_and_checkout_iuts(
+                minimum_amount=1,
+                maximum_amount=self.dataset.get(
+                    "maximum_amount",
+                    os.getenv(
+                        "ETOS_MAX_PARALELL",
+                        self.etos.config.get("TOTAL_TEST_COUNT"),
                     ),
-                )
-                self.splitter.assign_iuts(test_runners, iuts)
-                span.set_attribute(SemConvAttributes.IUT_DESCRIPTION, str(iuts))
+                ),
+            )
+            self.splitter.assign_iuts(test_runners, iuts)
 
             for test_runner in test_runners.keys():
                 self.dataset.add("test_runner", test_runner)


### PR DESCRIPTION
### Description of the Change
Make the default value for maximum amount configurable from the environment and the dataset. This allows for better control over the parallel-test feature in ETOS and gives the test operator the ability to tailor it specifically to their needs by setting the maximum_amount parameter in the dataset.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
