### PR TITLE
Step up etos_lib to 4.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography>=42.0.4,<43.0.0
 jsontas~=1.3
 packageurl-python~=0.11
 etcd3gw~=2.3
-etos_lib==4.2.0
+etos_lib==4.3.0
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography>=42.0.4,<43.0.0
 jsontas~=1.3
 packageurl-python~=0.11
 etcd3gw~=2.3
-etos_lib==4.3.0
+etos_lib==4.3.1
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     jsontas~=1.3
     packageurl-python~=0.11
     etcd3gw~=2.3
-    etos_lib==4.3.0
+    etos_lib==4.3.1
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     jsontas~=1.3
     packageurl-python~=0.11
     etcd3gw~=2.3
-    etos_lib==4.2.0
+    etos_lib==4.3.0
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/236

### Description of the Change

This change increments the version of etos_lib to 4.3.1 which corrects the format of opentelemetry_trace_id field in logstash entries (hex instead of dec).

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com