### PR TITLE
Catch the ConnectionError exception from requests

### DIFF
--- a/src/iut_provider/utilities/external_provider.py
+++ b/src/iut_provider/utilities/external_provider.py
@@ -230,6 +230,9 @@ class ExternalProvider:
                 )
                 self.check_error(response)
                 response = response.json()
+            except RequestsConnectionError as error:
+                self.logger.error("Error connecting to %r: %r", host, error)
+                continue
             except ConnectionError:
                 self.logger.error("Error connecting to %r", host)
                 continue


### PR DESCRIPTION
### Description of the Change
When waiting/polling for a status change we sometime might hit a ConnectionError for various reasons and this is totally
fine as we simply continue to try again if a ConnectionError Exception is thrown. The issue is that the ConnectionError we're trying to catch is the one from `Builtin` and not the one from `requests`. This PR adds catching ConnectionErrors trown by requests, as this is the library used to do the status-request agaisnt the iut-provider.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
