### PR TITLE
Add a 30s sleep as work around for log download race

### DIFF
--- a/src/environment_provider/environment.py
+++ b/src/environment_provider/environment.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Backend for the environment requests."""
 import json
+import time
 import traceback
 from typing import Optional, Union
 
@@ -121,6 +122,13 @@ def release_full_environment(etos: ETOS, jsontas: JsonTas, suite_id: str) -> tup
     """
     failure = None
     registry = ProviderRegistry(etos, jsontas, suite_id)
+    # TODO: Remove the sleeping when we can communicate the log urls to the
+    # etos-clinet using internal messaging via SSE.
+    #
+    # We need to sleep here for a while to prevent us from deleting the
+    # references to the last log files created before etos-client has time to
+    # download the.
+    time.sleep(30)
     for suite, metadata in registry.testrun.join("suite").read_all():
         suite = json.loads(suite)
         for sub_suite in suite.get("sub_suites", []):

--- a/src/environment_provider/environment.py
+++ b/src/environment_provider/environment.py
@@ -123,11 +123,11 @@ def release_full_environment(etos: ETOS, jsontas: JsonTas, suite_id: str) -> tup
     failure = None
     registry = ProviderRegistry(etos, jsontas, suite_id)
     # TODO: Remove the sleeping when we can communicate the log urls to the
-    # etos-clinet using internal messaging via SSE.
+    # etos-client using internal messaging via SSE.
     #
     # We need to sleep here for a while to prevent us from deleting the
-    # references to the last log files created before etos-client has time to
-    # download them.
+    # references to the last log files created. This is to ensure that
+    # etos-client has enough time to find and download them.
     time.sleep(30)
     for suite, metadata in registry.testrun.join("suite").read_all():
         suite = json.loads(suite)

--- a/src/environment_provider/environment.py
+++ b/src/environment_provider/environment.py
@@ -127,7 +127,7 @@ def release_full_environment(etos: ETOS, jsontas: JsonTas, suite_id: str) -> tup
     #
     # We need to sleep here for a while to prevent us from deleting the
     # references to the last log files created before etos-client has time to
-    # download the.
+    # download them.
     time.sleep(30)
     for suite, metadata in registry.testrun.join("suite").read_all():
         suite = json.loads(suite)

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -564,7 +564,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         except Exception as exception:  # pylint:disable=broad-except
             self.cleanup()
             traceback.print_exc()
-            self.logger.error("Failed creating environment for test. %r", extra={"user_log": True})
+            self.logger.error("Failed creating environment for test. %r", exception, extra={"user_log": True})
             return {"error": str(exception), "details": traceback.format_exc()}
         finally:
             if self.etos.publisher is not None and not self.etos.debug.disable_sending_events:

--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -564,7 +564,9 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         except Exception as exception:  # pylint:disable=broad-except
             self.cleanup()
             traceback.print_exc()
-            self.logger.error("Failed creating environment for test. %r", exception, extra={"user_log": True})
+            self.logger.error(
+                "Failed creating environment for test. %r", exception, extra={"user_log": True}
+            )
             return {"error": str(exception), "details": traceback.format_exc()}
         finally:
             if self.etos.publisher is not None and not self.etos.debug.disable_sending_events:


### PR DESCRIPTION
### Description of the Change
We have no garantue that all the logs have been downloaded when
we remove the main and subsuites from ETCD. This gives a potential
log area provider and the client a little more time to facilitate
download of the logs that were created last in the test run.

Also included a fix for an old annoing bug that provided a lackluster
error message to the user.

### Alternate Designs
As this is a simple workaround no other design were considered

### Possible Drawbacks
I tis unclear if the 30s sleep is enough for all situations

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
