### PR TITLE
Fix a problem where release_all is not run correctly

### DIFF
--- a/src/environment_provider/environment.py
+++ b/src/environment_provider/environment.py
@@ -36,7 +36,7 @@ from log_area_provider.log_area import LogArea
 
 TRACER = trace.get_tracer(__name__)
 # REGEX for matching /testrun/tercc-id/suite/main-suite-id/subsuite/subsuite-id/suite.
-REGEX = r"/testrun/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/suite/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/subsuite/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/suite"
+REGEX = r"/testrun/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/suite/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/subsuite/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/suite"  # pylint:disable=line-too-long
 
 
 def checkin_provider(

--- a/src/environment_provider/environment.py
+++ b/src/environment_provider/environment.py
@@ -17,6 +17,7 @@
 import json
 import time
 import traceback
+import re
 from typing import Optional, Union
 
 from etos_lib import ETOS
@@ -34,6 +35,8 @@ from log_area_provider.log_area import LogArea
 
 
 TRACER = trace.get_tracer(__name__)
+# REGEX for matching /testrun/tercc-id/suite/main-suite-id/subsuite/subsuite-id/suite.
+REGEX = r"/testrun/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/suite/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/subsuite/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/suite"
 
 
 def checkin_provider(
@@ -130,13 +133,15 @@ def release_full_environment(etos: ETOS, jsontas: JsonTas, suite_id: str) -> tup
     # etos-client has enough time to find and download them.
     time.sleep(30)
     for suite, metadata in registry.testrun.join("suite").read_all():
-        suite = json.loads(suite)
-        for sub_suite in suite.get("sub_suites", []):
-            try:
-                failure = release_environment(etos, jsontas, registry, sub_suite)
-            except json.JSONDecodeError as exception:
-                failure = exception
-        ETCDPath(metadata.get("key")).delete()
+        key = metadata.get("key", b"").decode()
+        if re.match(REGEX, key) is None:
+            continue
+        try:
+            sub_suite = json.loads(suite)
+            failure = release_environment(etos, jsontas, registry, sub_suite)
+        except json.JSONDecodeError as exception:
+            failure = exception
+        ETCDPath(key).delete()
     registry.testrun.delete_all()
 
     if failure:


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
None

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
`release_full_environment` never ran `release_environment` because it tried to iterate over `sub_suites` in a dictionary that does not have that key. The default value is then an empty list which we don't iterate over.
Fix the code so that the correct key is retrieved from ETCD.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
None

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
