### PR TITLE
Compatibility fix for latest tox and setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,3 @@ build_dir = "build/sphinx"
 [tool.devpi.upload]
 no-vcs = 1
 formats = "bdist_wheel"
-
-[tool.setuptools_scm]
-version_scheme = "setup:version_scheme"
-local_scheme = "setup:local_scheme"

--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,4 @@ def local_scheme(version) -> str:
 
 
 if __name__ == "__main__":
-    setup()
+    setup(use_scm_version={"local_scheme": local_scheme, "version_scheme": version_scheme})

--- a/src/environment_provider/lib/log_area.py
+++ b/src/environment_provider/lib/log_area.py
@@ -28,7 +28,7 @@ from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
 
-# pylint:disable=too-many-arguments
+# pylint:disable=too-many-arguments,too-many-positional-arguments
 
 
 class LogArea:  # pylint:disable=too-few-public-methods


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/284

### Description of the Change
This change fixes the compatibility problem with tox/setuptools by moving the options from `pyproject.toml` to `setup.py`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com