### PR TITLE
Environment(Request): make identifier optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir build && python3 -m build
 
 FROM python:3.9-slim-bookworm
 
-COPY --from=build /src/dist/*.whl /tmp
+COPY --from=build /src/dist/*.whl /tmp/
 # hadolint ignore=DL3013
 
 RUN pip install --no-cache-dir /tmp/*.whl && groupadd -r etos && useradd -r -m -s /bin/false -g etos etos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "jsontas~=1.3",
     "packageurl-python~=0.11",
     "etcd3gw~=2.3",
-    "etos-lib==4.4.2",
+#    "etos-lib==4.4.2", # TODO: update
     "opentelemetry-api~=1.21",
     "opentelemetry-exporter-otlp~=1.21",
     "opentelemetry-sdk~=1.21",

--- a/src/environment_provider/environment.py
+++ b/src/environment_provider/environment.py
@@ -123,7 +123,7 @@ def release_full_environment(etos: ETOS, jsontas: JsonTas, suite_id: str) -> tup
     :return: Release status and a message if status is False.
     """
     failure = None
-    registry = ProviderRegistry(etos, jsontas, suite_id)
+    registry = ProviderRegistry(etos, jsontas).with_suite_id(suite_id)
     # TODO: Remove the sleeping when we can communicate the log urls to the
     # etos-client using internal messaging via SSE.
     #

--- a/src/environment_provider/lib/config.py
+++ b/src/environment_provider/lib/config.py
@@ -186,7 +186,7 @@ class Config:
 
         test_suites = self.__test_suite(tercc)
 
-        registry = ProviderRegistry(self.etos, JsonTas(), tercc["meta"]["id"])
+        registry = ProviderRegistry(self.etos, JsonTas()).with_suite_id(tercc["meta"]["id"])
 
         datasets = registry.dataset()
         if isinstance(datasets, list):

--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -204,7 +204,7 @@ class ExternalProvider:
         data = {
             "minimum_amount": minimum_amount,
             "maximum_amount": maximum_amount,
-            "identity": self.identity.to_string(),
+            "identity": self.identity.to_string() if self.identity else "", # TODO: remove if-statement
             "test_runner": self.dataset.get("test_runner"),
             "environment": {  # All environments must be string
                 "RABBITMQ_HOST": rabbitmq.get("host"),


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/266

### Description of the Change
This change introduces handling of environment requests and environments that aren't bound to suite id/testrun and thus have no `identifier` attribute. This allows creating `EnvironmentRequest` / `Environment` objects without a testrun using Kubernetes API directly.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com