### PR TITLE
Migrate container images to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,10 @@ on:
       - closed
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build_docker:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Build and push docker image
 on:
   pull_request_target:
     branches: [ "main" ]
-    #types:
-    #  - closed
+    types:
+      - closed
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Build and push docker image
 on:
   pull_request_target:
     branches: [ "main" ]
-    types:
-      - closed
+    #types:
+    #  - closed
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,13 +16,17 @@ jobs:
     - name: Build app image
       run: docker build . --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-environment-provider
+        IMAGE_ID=ghcr.io/eiffel-community/etos-environment-provider
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name

--- a/manifests/base/api/deployment.yaml
+++ b/manifests/base/api/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: etos-environment-provider
       containers:
         - name: etos-environment-provider
-          image: registry.nordix.org/eiffel/etos-environment-provider:191ed4e7
+          image: ghcr.io/eiffel-community/etos-environment-provider:191ed4e7
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/manifests/base/worker/deployment.yaml
+++ b/manifests/base/worker/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: etos-environment-provider-worker
       containers:
         - name: etos-environment-provider-worker
-          image: registry.nordix.org/eiffel/etos-environment-provider-worker:191ed4e7
+          image: ghcr.io/eiffel-community/etos-environment-provider-worker:191ed4e7
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/tests/tercc.py
+++ b/tests/tercc.py
@@ -42,7 +42,7 @@ TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -64,7 +64,7 @@ TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.7.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.7.0",
                             },
                         ],
                     },
@@ -108,7 +108,7 @@ TERCC = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -152,7 +152,7 @@ TERCC_PERMUTATION = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -180,7 +180,7 @@ TERCC_PERMUTATION = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/343

### Description of the Change
This pull request changes all docker image references from `nordix.org/eiffel` to `ghcr.io/eiffel-community`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com