### PR TITLE
Rename ENVIRONMENT_PROVIDER_WAIT* envvar refs to ETOS_WAIT*

### DIFF
--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -114,7 +114,7 @@ class ExternalProvider:
         """
         end = self.etos.config.get("WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
         if end is None:
-            end = os.getenv("ENVIRONMENT_PROVIDER_WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
+            end = os.getenv("ETOS_WAIT_FOR_EXECUTION_SPACE_TIMEOUT")
         if end is None:
             end = 3600
         end = int(end)

--- a/src/iut_provider/utilities/external_provider.py
+++ b/src/iut_provider/utilities/external_provider.py
@@ -107,7 +107,7 @@ class ExternalProvider:
         """
         end = self.etos.config.get("WAIT_FOR_IUT_TIMEOUT")
         if end is None:
-            end = os.getenv("ENVIRONMENT_PROVIDER_WAIT_FOR_IUT_TIMEOUT")
+            end = os.getenv("ETOS_WAIT_FOR_IUT_TIMEOUT")
         if end is None:
             end = 3600
         end = int(end)

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -107,7 +107,7 @@ class ExternalProvider:
         """
         end = self.etos.config.get("WAIT_FOR_LOG_AREA_TIMEOUT")
         if end is None:
-            end = os.getenv("ENVIRONMENT_PROVIDER_WAIT_FOR_LOG_AREA_TIMEOUT")
+            end = os.getenv("ETOS_WAIT_FOR_LOG_AREA_TIMEOUT")
         if end is None:
             end = 3600
         end = int(end)


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This change renames environment variable references `ENVIRONMENT_PROVIDER_WAIT*` to `ETOS_WAIT_*`, i. e. to unify them with code in  `src/environment_provider/environment_provider.py`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com