### PR TITLE
Remove in-library telemetry signals environment logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "jsontas~=1.3",
     "packageurl-python~=0.11",
     "etcd3gw~=2.3",
-    "etos-lib==4.5.0",
+    "etos-lib==5.1.2",
     "opentelemetry-api~=1.21",
     "opentelemetry-exporter-otlp~=1.21",
     "opentelemetry-sdk~=1.21",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography>=42.0.4,<43.0.0
 jsontas~=1.3
 packageurl-python~=0.11
 etcd3gw~=2.3
-etos-lib==4.5.0
+etos-lib==5.1.2
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/src/environment_provider/__init__.py
+++ b/src/environment_provider/__init__.py
@@ -24,7 +24,6 @@ except PackageNotFoundError:
     VERSION = "Unknown"
 
 DEV = os.getenv("DEV", "false").lower() == "true"
-ENVIRONMENT = "development" if DEV else "production"
 
 # JSONTas would print all passwords as they are encrypted,
 # which is not safe, so we disable propagation on the loggers.


### PR DESCRIPTION
### Description of the Change
Since the logic to figure out in what environment the library is running
is very limited, we remove the logic and let it be handled better
somewhere outside of the library.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
