### PR TITLE
Get traceparent from environment when running in controller env

### DIFF
--- a/src/environment_provider/lib/otel_tracing.py
+++ b/src/environment_provider/lib/otel_tracing.py
@@ -1,0 +1,54 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenTelemetry-related code."""
+import logging
+import os
+
+import opentelemetry
+from opentelemetry.propagators.textmap import Getter
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EnvVarContextGetter(Getter):
+    """OpenTelemetry context getter class for environment variables."""
+
+    def get(self, carrier, key):
+        """Get value using the given carrier variable and key."""
+        value = os.getenv(carrier)
+        if value is not None and value != "":
+            pairs = value.split(",")
+            for pair in pairs:
+                k, v = pair.split("=", 1)
+                if k == key:
+                    return [v]
+        return []
+
+    def keys(self, carrier):
+        """Get keys of the given carrier variable."""
+        value = os.getenv(carrier)
+        if value is not None:
+            return [pair.split("=")[0] for pair in value.split(",") if "=" in pair]
+        return []
+
+
+def get_current_context() -> opentelemetry.context.context.Context:
+    """Get current context propagated via environment variable OTEL_CONTEXT."""
+    propagator = TraceContextTextMapPropagator()
+    ctx = propagator.extract(carrier="OTEL_CONTEXT", getter=EnvVarContextGetter())
+    return ctx


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
Found no issue

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
When we are running in the controller environment we don't use the environment provider as a library and won't automatically get the trace parent from the suite runner.
We now assume that the ETOS controller will pass the traceparent to the environment provider job as an environment variable and load it.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
We could've created a new span for the v0 environment as well, but I don't want to change the trace for v0 at this moment.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
This will mean that there's a slight difference in the trace produced from the controller environment vs the v0 environment, but I don't see a big problem with that since the controller environment does do the environment checkout a bit differently and that will be reflected in the trace.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
