### PR TITLE
lib/log_area.py: more robust retry policy

### DIFF
--- a/src/environment_provider/lib/log_area.py
+++ b/src/environment_provider/lib/log_area.py
@@ -20,9 +20,11 @@ import traceback
 from copy import deepcopy
 from json.decoder import JSONDecodeError
 from typing import IO, Optional, Union
+from urllib3.util import Retry
 
 from cryptography.fernet import Fernet
 from etos_lib import ETOS
+from etos_lib.lib.http import Http
 from requests import Response
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -30,6 +32,17 @@ from requests.exceptions import HTTPError
 
 # pylint:disable=too-many-arguments
 # pylint:disable=too-many-positional-arguments
+
+max_retries = 10  # With 1 as backoff_factor, the total wait time between retries will be 1023 seconds
+HTTP_RETRY_PARAMETERS = Retry(
+    total=None,
+    read=max_retries,
+    connect=max_retries,
+    status=max_retries,
+    backoff_factor=1,
+    other=0,
+    status_forcelist=list(Retry.RETRY_AFTER_STATUS_CODES),
+)
 
 
 class LogArea:  # pylint:disable=too-few-public-methods
@@ -46,6 +59,7 @@ class LogArea:  # pylint:disable=too-few-public-methods
         self.etos = etos
         self.suite_name = sub_suite.get("name").replace(" ", "-")
         self.log_area = sub_suite.get("log_area")
+        self.http = Http(retry=HTTP_RETRY_PARAMETERS)
 
     def upload(self, log: str, name: str, main_suite_id: str, sub_suite_id: str) -> str:
         """Upload log to a storage location.
@@ -68,20 +82,19 @@ class LogArea:  # pylint:disable=too-few-public-methods
             upload["auth"] = self.__auth(**upload["auth"])
 
         with open(log, "rb") as log_file:
-            for _ in range(3):
-                try:
-                    response = self.__upload(log_file=log_file, **upload)
-                    self.logger.debug("%r", response)
-                    if not upload.get("as_json", True):
-                        self.logger.debug("%r", response.text)
-                    self.logger.info("Uploaded log %r.", log)
-                    self.logger.info("Upload URI          %r", upload["url"])
-                    self.logger.info("Data:               %r", data)
-                    break
-                except:  # noqa pylint:disable=bare-except
-                    self.logger.error("%r", traceback.format_exc())
-                    self.logger.error("Failed to upload log!")
-                    self.logger.error("Attempted upload of %r", log)
+            try:
+                response = self.__upload(log_file=log_file, **upload)
+                self.logger.debug("%r", response)
+                if not upload.get("as_json", True):
+                    self.logger.debug("%r", response.text)
+                self.logger.info("Uploaded log %r.", log)
+                self.logger.info("Upload URI          %r", upload["url"])
+                self.logger.info("Data:               %r", data)
+            except Exception as error:
+                self.logger.error("%r", traceback.format_exc())
+                self.logger.error("Failed to upload log!")
+                self.logger.error("Attempted upload of %r", log)
+                raise error
         return upload["url"]
 
     def __upload(
@@ -108,7 +121,7 @@ class LogArea:  # pylint:disable=too-few-public-methods
             timeout = self.etos.debug.default_http_timeout
         self.logger.debug("Retrying URL %s for %d seconds with a %s request.", url, timeout, verb)
 
-        method = getattr(self.etos.http, verb.lower())
+        method = getattr(self.http, verb.lower())
         try:
             response = method(url, data=log_file, timeout=timeout, **requests_kwargs)
             response.raise_for_status()


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/424

### Description of the Change

This change modifies the `LogArea` class to use its own HTTP client with a more robust retry policy, which is similar to the log downloader in the ETOS Client. The old retry loop with 3 iterations is removed from the `upload()` method.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com