### PR TITLE
Enable baggage support and use the EnvironmentGetter from OTEL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ dependencies = [
     "packageurl-python~=0.11",
     "etcd3gw~=2.3",
     "etos-lib==5.1.6",
-    "opentelemetry-api~=1.21",
-    "opentelemetry-exporter-otlp~=1.21",
-    "opentelemetry-sdk~=1.21",
+    "opentelemetry-api~=1.40",
+    "opentelemetry-exporter-otlp~=1.40",
+    "opentelemetry-sdk~=1.40",
 ]
 
 [project.urls]

--- a/src/environment_provider/lib/otel_tracing.py
+++ b/src/environment_provider/lib/otel_tracing.py
@@ -19,6 +19,9 @@ import logging
 import os
 
 import opentelemetry
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.propagators._envcarrier import EnvironmentGetter
+from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.propagators.textmap import Getter
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
@@ -49,6 +52,19 @@ class EnvVarContextGetter(Getter):
 
 def get_current_context() -> opentelemetry.context.context.Context:
     """Get current context propagated via environment variable OTEL_CONTEXT."""
-    propagator = TraceContextTextMapPropagator()
-    ctx = propagator.extract(carrier="OTEL_CONTEXT", getter=EnvVarContextGetter())
+    propagator = CompositePropagator(
+        (
+            TraceContextTextMapPropagator(),
+            W3CBaggagePropagator(),
+        )
+    )
+    ctx = opentelemetry.context.get_current()
+    old_style_traceparent = EnvironmentGetter().get({}, "OTEL_CONTEXT")
+    if old_style_traceparent is not None:
+        LOGGER.warning(
+            "OTEL_CONTEXT environment variable is deprecated; use TRACEPARENT and BAGGAGE "
+            "variables instead."
+        )
+        ctx = propagator.extract(carrier="OTEL_CONTEXT", context=ctx, getter=EnvVarContextGetter())
+    ctx = propagator.extract(carrier={}, context=ctx, getter=EnvironmentGetter())
     return ctx

--- a/src/environment_provider/lib/otel_tracing.py
+++ b/src/environment_provider/lib/otel_tracing.py
@@ -51,7 +51,7 @@ class EnvVarContextGetter(Getter):
 
 
 def get_current_context() -> opentelemetry.context.context.Context:
-    """Get current context propagated via environment variable OTEL_CONTEXT."""
+    """Get current context propagated via environment variables."""
     propagator = CompositePropagator(
         (
             TraceContextTextMapPropagator(),


### PR DESCRIPTION

<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Instead of rolling our own environment getter, let's use the one from opentelemetry. It is in beta (as per the underscore import) but should work better than our own.

Updated the opentelemetry versions to get envcarrier support.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I could add support for reading baggage to the envcarrier we implemented, but it felt wrong to do that when the opentelemetry maintainers have already added something that works as intended.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
We are using a beta version of the envcarrier and it may change in the future.
I'm not that scared of it for the suite runner though since it does not get automatically deployed, so we will catch it before it causes harm.
I also changed the environment variable from OTEL_CONTEXT to TRACEPARENT, TRACESTATE and BAGGAGE. But I kept a fallback to OTEL_CONTEXT if set since changing everywhere at once would be a real pain. The OTEL_CONTEXT variable is marked as deprecated.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
