### PR TITLE
Pass client arg to Lease for etcd3gw 2.6 compatibility

### DIFF
--- a/tests/library/fake_database.py
+++ b/tests/library/fake_database.py
@@ -86,8 +86,8 @@ class FakeDatabase:
             self.expire.append(ttl)
         # ttl is unused since we do not actually make the post request that the regular
         # etcd client does. First argument to `Lease` is the ID that was returned by the
-        # etcd server.
-        return Lease(len(self.expire) - 1)
+        # etcd server. The client argument is required by etcd3gw >= 2.6.0 but unused here.
+        return Lease(len(self.expire) - 1, client=None)
 
     def get(self, path: str) -> list[bytes]:
         """Get an item from database."""


### PR DESCRIPTION
### Applicable Issues



### Description of the Change

Fix pylint E1120 (no-value-for-parameter) in `tests/library/fake_database.py`. The `etcd3gw` dependency uses a compatible release pin (`~=2.3`), so the newly released 2.6.0 was picked up, which made the `client` parameter in `Lease.__init__` required. This passes `client=None` explicitly.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com