### PR TITLE
Use EVENT_DATA_TIMEOUT when waiting for test suite started

### DIFF
--- a/src/environment_provider/environment_provider.py
+++ b/src/environment_provider/environment_provider.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 """ETOS Environment Provider module."""
 
-import sys
 import json
 import logging
 import os
+import sys
 import time
 import traceback
 import uuid
@@ -27,36 +27,33 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Optional
 
 from etos_lib.etos import ETOS
+from etos_lib.kubernetes import Environment, Kubernetes, Provider
+from etos_lib.kubernetes.schemas import Environment as EnvironmentSchema
+from etos_lib.kubernetes.schemas import EnvironmentRequest as EnvironmentRequestSchema
+from etos_lib.kubernetes.schemas import EnvironmentSpec, Metadata
+from etos_lib.kubernetes.schemas import Provider as ProviderSchema
+from etos_lib.kubernetes.schemas import Test
+from etos_lib.kubernetes.schemas.common import OwnerReference
 from etos_lib.lib.events import EiffelEnvironmentDefinedEvent
 from etos_lib.logging.logger import FORMAT_CONFIG
 from etos_lib.opentelemetry.semconv import Attributes as SemConvAttributes
-from etos_lib.kubernetes import Kubernetes, Environment, Provider
-from etos_lib.kubernetes.schemas.common import OwnerReference
-from etos_lib.kubernetes.schemas import (
-    Environment as EnvironmentSchema,
-    EnvironmentSpec,
-    Metadata,
-)
-from etos_lib.kubernetes.schemas import Test
-from etos_lib.kubernetes.schemas import Provider as ProviderSchema
-from etos_lib.kubernetes.schemas import EnvironmentRequest as EnvironmentRequestSchema
 from jsontas.jsontas import JsonTas
-from packageurl import PackageURL
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
+from packageurl import PackageURL
 
 from execution_space_provider.execution_space import ExecutionSpace
 from log_area_provider.log_area import LogArea
 
 from .lib.config import Config
-from .lib.otel_tracing import get_current_context
+from .lib.database import ETCDPath
 from .lib.encrypt import Encrypt
 from .lib.graphql import request_main_suite
 from .lib.join import Join
 from .lib.json_dumps import JsonDumps
 from .lib.log_area import LogArea
+from .lib.otel_tracing import get_current_context
 from .lib.registry import ProviderRegistry
-from .lib.database import ETCDPath
 from .lib.test_suite import TestSuite
 from .lib.uuid_generate import UuidGenerate
 from .splitter.split import Splitter
@@ -525,7 +522,7 @@ class EnvironmentProvider:  # pylint:disable=too-many-instance-attributes
         :return: a test suite started event.
         """
         main_suite = request_main_suite(self.etos, test_suite_id)
-        timeout = time.time() + 30
+        timeout = time.time() + self.etos.config.get("EVENT_DATA_TIMEOUT")
         while main_suite is None and time.time() < timeout:
             main_suite = request_main_suite(self.etos, test_suite_id)
             time.sleep(5)

--- a/tests/library/fake_database.py
+++ b/tests/library/fake_database.py
@@ -19,6 +19,7 @@ from queue import Queue
 from threading import Event, RLock, Timer
 from typing import Any, Iterator, Optional
 
+from etcd3gw import Etcd3Client
 from etcd3gw.lease import Lease
 
 # pylint:disable=unused-argument
@@ -87,7 +88,7 @@ class FakeDatabase:
         # ttl is unused since we do not actually make the post request that the regular
         # etcd client does. First argument to `Lease` is the ID that was returned by the
         # etcd server.
-        return Lease(len(self.expire) - 1)
+        return Lease(len(self.expire) - 1, client=Etcd3Client())
 
     def get(self, path: str) -> list[bytes]:
         """Get an item from database."""


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Make it possible to configure the timeout when waiting for test suite started.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I changed the import ordering (because of isort), which is something I could fix so that the review becomes easier.
If it is a problem, then I'll remove that change.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
Because the default timeout when deploying using Cluster is 60s, we have now doubled the timeout with this change. Should not be a problem.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
