### PR TITLE
Set ENVIRONMENT_URL for v1alpha testruns

### DIFF
--- a/src/execution_space_provider/utilities/instructions.py
+++ b/src/execution_space_provider/utilities/instructions.py
@@ -39,9 +39,9 @@ class Instructions(DataStructure):  # pylint:disable=too-few-public-methods
         instructions["environment"]["ENVIRONMENT_ID"] = environment_id
         etos_api = os.getenv("ETOS_API")
         if etos_api and os.getenv("REQUEST"):
-            instructions["environment"]["ENVIRONMENT_URL"] = (
-                f"{etos_api}/v1alpha/testrun/{environment_id}"
-            )
+            instructions["environment"][
+                "ENVIRONMENT_URL"
+            ] = f"{etos_api}/v1alpha/testrun/{environment_id}"
         if instructions["environment"].get("ETR_VERSION") is None:
             instructions["environment"]["ETR_VERSION"] = os.getenv("ETR_VERSION")
         self.add_feature_flags(instructions)

--- a/src/execution_space_provider/utilities/instructions.py
+++ b/src/execution_space_provider/utilities/instructions.py
@@ -35,7 +35,13 @@ class Instructions(DataStructure):  # pylint:disable=too-few-public-methods
         instructions["parameters"].update(self.data.get("parameters", {}))
         instructions["image"] = self.data.get("image", instructions["image"])
         instructions["identifier"] = str(uuid4())
-        instructions["environment"]["ENVIRONMENT_ID"] = str(uuid4())
+        environment_id = str(uuid4())
+        instructions["environment"]["ENVIRONMENT_ID"] = environment_id
+        etos_api = os.getenv("ETOS_API")
+        if etos_api and os.getenv("REQUEST"):
+            instructions["environment"]["ENVIRONMENT_URL"] = (
+                f"{etos_api}/v1alpha/testrun/{environment_id}"
+            )
         if instructions["environment"].get("ETR_VERSION") is None:
             instructions["environment"]["ETR_VERSION"] = os.getenv("ETR_VERSION")
         self.add_feature_flags(instructions)


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/622

### Description of the Change

Set `ENVIRONMENT_URL` in execution space instructions for v1alpha testruns so the ETR can fetch its sub suite directly from the ETOS API instead of polling the Event Repository. This aligns the Python environment provider with the Go execution space provider, which already sets both `ENVIRONMENT_ID` and `ENVIRONMENT_URL`. Only applies when `REQUEST` and `ETOS_API` env vars are present (i.e. ETOS controller mode).

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com