### PR TITLE
Serialize iut and executor as dict in provider requests

### DIFF
--- a/src/execution_space_provider/utilities/external_provider.py
+++ b/src/execution_space_provider/utilities/external_provider.py
@@ -201,12 +201,13 @@ class ExternalProvider:
                 etos_rabbitmq_password.encode(), os.getenv("ETOS_ENCRYPTION_KEY", "")
             )
         source = self.etos.config.get("source") or {}
+        iut = self.dataset.get("iut")
         data = {
             "minimum_amount": minimum_amount,
             "maximum_amount": maximum_amount,
             "identity": self.identity.to_string(),
             "test_runner": self.dataset.get("test_runner"),
-            "iut": self.dataset.get("iut"),
+            "iut": iut.as_dict if iut is not None else None,
             "environment": {  # All environments must be string
                 "RABBITMQ_HOST": rabbitmq.get("host"),
                 "RABBITMQ_USERNAME": rabbitmq.get("username"),

--- a/src/log_area_provider/utilities/external_provider.py
+++ b/src/log_area_provider/utilities/external_provider.py
@@ -175,6 +175,8 @@ class ExternalProvider:
         :return: The ID of the external log area provider request.
         """
         self.logger.debug("Start external log area provider")
+        iut = self.dataset.get("iut")
+        executor = self.dataset.get("executor")
         data = {
             "minimum_amount": minimum_amount,
             "maximum_amount": maximum_amount,
@@ -185,8 +187,8 @@ class ExternalProvider:
             "tercc": self.dataset.get("tercc"),
             "dataset": self.dataset.get("dataset"),
             "context": self.dataset.get("context"),
-            "iut": self.dataset.get("iut"),
-            "executor": self.dataset.get("executor"),
+            "iut": iut.as_dict if iut is not None else None,
+            "executor": executor.as_dict if executor is not None else None,
         }
         host = self.ruleset.get("start", {}).get("host")
         headers = {"X-ETOS-ID": self.identifier}

--- a/tests/external_execution_space/test_external_execution_space.py
+++ b/tests/external_execution_space/test_external_execution_space.py
@@ -31,6 +31,7 @@ from execution_space_provider.exceptions import (
 )
 from execution_space_provider.execution_space import ExecutionSpace
 from execution_space_provider.utilities.external_provider import ExternalProvider
+from iut_provider.iut import Iut
 from tests.library.fake_server import FakeServer
 
 
@@ -78,6 +79,46 @@ class TestExternalExecutionSpace(unittest.TestCase):
             start_id = provider.start(1, 2)
             self.logger.info("STEP: Verify that the ID from the start request is returned.")
             self.assertEqual(start_id, expected_start_id)
+
+    def test_provider_start_serializes_iut(self):
+        """Test that a checked out IUT is serialized in the start request.
+
+        Approval criteria:
+            - The start request payload shall be JSON serializable when an IUT is
+              present in the dataset.
+
+        Test steps::
+            1. Initialize an external provider with an IUT in the dataset.
+            2. Send a start request.
+            3. Verify that the IUT was sent as a dictionary.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        iut = Iut(provider_id="test", identity=PackageURL.from_string("pkg:testing/etos"))
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+                "iut": iut,
+            }
+        )
+        expected_start_id = "123"
+
+        with FakeServer("ok", {"id": expected_start_id}) as server:
+            ruleset = {"id": "test_provider_start_serializes_iut", "start": {"host": server.host}}
+            self.logger.info("STEP: Initialize an external provider with an IUT in the dataset.")
+            provider = ExternalProvider(etos, jsontas, ruleset)
+            provider.http.adapter.max_retries.status = 1
+            self.logger.info("STEP: Send a start request.")
+            start_id = provider.start(1, 2)
+            self.logger.info("STEP: Verify that the IUT was sent as a dictionary.")
+            self.assertEqual(start_id, expected_start_id)
+            self.assertEqual(server.requests[0]["iut"], iut.as_dict)
 
     def test_provider_start_http_exception(self):
         """Test that the start method tries again if there's an HTTP error.

--- a/tests/external_log_area/test_external_log_area.py
+++ b/tests/external_log_area/test_external_log_area.py
@@ -31,6 +31,8 @@ from log_area_provider.exceptions import (
 )
 from log_area_provider.log_area import LogArea
 from log_area_provider.utilities.external_provider import ExternalProvider
+from execution_space_provider.execution_space import ExecutionSpace
+from iut_provider.iut import Iut
 from tests.library.fake_server import FakeServer
 
 
@@ -78,6 +80,54 @@ class TestExternalLogArea(unittest.TestCase):
             start_id = provider.start(1, 2)
             self.logger.info("STEP: Verify that the ID from the start request is returned.")
             self.assertEqual(start_id, expected_start_id)
+
+    def test_provider_start_serializes_iut_and_executor(self):
+        """Test that a checked out IUT and executor are serialized in the start request.
+
+        Approval criteria:
+            - The start request payload shall be JSON serializable when an IUT and
+              an executor are present in the dataset.
+
+        Test steps::
+            1. Initialize an external provider with an IUT and executor in the dataset.
+            2. Send a start request.
+            3. Verify that the IUT and executor were sent as dictionaries.
+        """
+        etos = ETOS("testing_etos", "testing_etos", "testing_etos")
+        jsontas = JsonTas()
+        iut = Iut(provider_id="test", identity=PackageURL.from_string("pkg:testing/etos"))
+        executor = ExecutionSpace(test_execution_space=1)
+        jsontas.dataset.merge(
+            {
+                "identity": PackageURL.from_string("pkg:testing/etos"),
+                "artifact_id": "artifactid",
+                "artifact_created": "artifactcreated",
+                "artifact_published": "artifactpublished",
+                "tercc": "tercc",
+                "dataset": {},
+                "context": "context",
+                "iut": iut,
+                "executor": executor,
+            }
+        )
+        expected_start_id = "123"
+
+        with FakeServer("ok", {"id": expected_start_id}) as server:
+            ruleset = {
+                "id": "test_provider_start_serializes_iut_and_executor",
+                "start": {"host": server.host},
+            }
+            self.logger.info(
+                "STEP: Initialize an external provider with an IUT and executor in the dataset."
+            )
+            provider = ExternalProvider(etos, jsontas, ruleset)
+            provider.http.adapter.max_retries.status = 1
+            self.logger.info("STEP: Send a start request.")
+            start_id = provider.start(1, 2)
+            self.logger.info("STEP: Verify that the IUT and executor were sent as dictionaries.")
+            self.assertEqual(start_id, expected_start_id)
+            self.assertEqual(server.requests[0]["iut"], iut.as_dict)
+            self.assertEqual(server.requests[0]["executor"], executor.as_dict)
 
     def test_provider_start_http_exception(self):
         """Test that the start method tries again if there's an HTTP error.


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/717

### Description of the Change

The execution space and log area external providers added the raw `Iut` and `ExecutionSpace` objects to their start request payloads, which are not JSON serializable and caused environment checkout to fail. This converts them to their `as_dict` representation and adds regression tests.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
